### PR TITLE
Fix compilation flags and improve string manipulation functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ USE_ZIG ?= 0
 ifeq ($(USE_ZIG), 1)
     CC = zig cc -target x86-freestanding-none
     LD = zig ld.lld
-    CFLAGS = -ffreestanding -O2 -Wall -Wextra -m32 -Isrc/include -fno-pie -fno-stack-protector -mgeneral-regs-only -fno-sanitize=all
+    CFLAGS = -ffreestanding -Wall -Wextra -m32 -Isrc/include -fno-pie -fno-stack-protector -mgeneral-regs-only -fno-sanitize=all
     LDFLAGS = -T linker.ld -nostdlib -z max-page-size=0x1000 --build-id=none
 else
     CC = i686-elf-gcc

--- a/src/cpu/isr.c
+++ b/src/cpu/isr.c
@@ -43,6 +43,8 @@ void isr_handler(registers_t *regs)
         terminal_writestring(exception_messages[regs->int_no]);
         terminal_writestring("\n");
 
-        for (;;);
+        for (;;) {
+          asm volatile("cli; hlt");
+        };
     }
 }

--- a/src/include/string.h
+++ b/src/include/string.h
@@ -11,6 +11,6 @@ int str_is_uppercase(char *str);
 int str_is_lowercase(char *str);
 char *strupcase(char *str);
 char *strlowcase(char *str);
-char strcpy(char *src, char *dest);
+char *strcpy(char *dest, const char *src);
 
 #endif

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -63,9 +63,7 @@ void *memcpy(void *dest, const void *src, size_t len) {
 }
 
 
-// The  memmove()  function copies n bytes from memory area src to memory area dest.  The memory areas may overlap: copying takes place
-// as though the bytes in src are first copied into a temporary array that does not overlap src or dest, and the bytes are then  copied
-// from the temporary array to dest.
+// Cpoy memory zone taking into account the overlap
 void *memmove(void *dest, const void *src, size_t n) {
     unsigned char *d = (unsigned char *)dest;
     const unsigned char *s = (const unsigned char *)src;

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -62,6 +62,29 @@ void *memcpy(void *dest, const void *src, size_t len) {
     return dest;
 }
 
+
+// The  memmove()  function copies n bytes from memory area src to memory area dest.  The memory areas may overlap: copying takes place
+// as though the bytes in src are first copied into a temporary array that does not overlap src or dest, and the bytes are then  copied
+// from the temporary array to dest.
+void *memmove(void *dest, const void *src, size_t n) {
+    unsigned char *d = (unsigned char *)dest;
+    const unsigned char *s = (const unsigned char *)src;
+
+    if (d == s) return dest;
+
+    if (d < s) 
+      return memcpy(dest, src, n);
+    else
+    {
+      d += n;
+      s += n;
+      while (n--) {
+        *(--d) = *(--s);
+      }
+    }
+    return dest;
+}
+
 // Copy up to n bytes or until character c is found
 void *memccpy(void *dest, const void *src, int c, size_t n) {
     unsigned char *d = dest;
@@ -78,7 +101,7 @@ void *memccpy(void *dest, const void *src, int c, size_t n) {
 }
 
 // Duplicate a string pointer
-char *strdup(char *src)
+char *strdup(const char *src)
 {
 	char *cpy = malloc(sizeof(char) * (strlen(src) + 1));
 	if (cpy == NULL)
@@ -112,6 +135,4 @@ void free(void *ptr)
     block_header_t *block = (block_header_t *)((uint8_t *)ptr - HEADER_SIZE);
     if (block != 0)
         block->free = 1;
-    else
-        block->free = 0;
 }

--- a/src/lib/string.c
+++ b/src/lib/string.c
@@ -118,11 +118,12 @@ char *strlowcase(char *str)
 }
 
 // Copy a string from a source to a destination
-char strcpy(char *src, char *dest) {
+char *strcpy(char *dest, const char *src) {
     int i = 0;
     while (src[i] != '\0') {
         dest[i] = src[i];
         i++;
     }
-    return(*dest);
+    dest[i] = 0;
+    return(dest);
 }


### PR DESCRIPTION
I'm slowly getting back into C, so I'm starting with small, simple pull requests to improve the codebase.

This pull request introduces several improvements and fixes to string and memory handling functions, as well as some updates to exception handling and build configuration. The most significant changes are the addition of a new `memmove` implementation, corrections to string function signatures, and improved safety in the interrupt handler.

### Memory and String Function Improvements

* Added a new implementation of `memmove` in `src/lib/memory.c`, ensuring correct behavior when memory regions overlap.
* Fixed the signature and implementation of `strcpy` in both `src/include/string.h` and `src/lib/string.c`, making it compatible with standard C by accepting `dest` first and returning a `char *`. [[1]](diffhunk://#diff-aea7e071810c24807245f61006a4eec5be0f39f9634f5aad2fa2f0c8d120f30cL14-R14) [[2]](diffhunk://#diff-c422a364cb2ecb2f5baac647d0e80e001aa65eaacb094b4a5bfdaa2c2e4f879cL121-R128)
* Updated `strdup` to take a `const char *` argument for better const-correctness.

### Exception and Interrupt Handling

* Modified the infinite loop in `isr_handler` (in `src/cpu/isr.c`) to explicitly disable interrupts and halt the CPU when an exception occurs, improving system stability during faults.

### Build System

* The `-O2` optimization option of `CFLAGS` has been removed from the `Makefile` when compiling with Zig, as the optimization is too aggressive and alters the logic.

### Memory Management

* Simplified the `free` function in `src/lib/memory.c` by removing an unnecessary `else` clause, making the code clearer.