### PR TITLE
poc: add a ansi parser in zig to make it more readable & easy to code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,15 @@ AS = nasm
 C_SOURCES = $(wildcard src/kernel/*.c) $(wildcard src/cpu/*.c) $(wildcard src/lib/*.c) $(wildcard src/drivers/*.c)
 S_SOURCES = $(wildcard src/boot/*.s)
 ASM_SOURCES = $(wildcard src/cpu/*.asm)
+ZIG_SOURCES = $(wildcard src/kernel/*.zig)
+ZIG_OBJS = $(patsubst src/%.zig, $(BUILD_DIR)/%.o, $(ZIG_SOURCES))
 
 # Object files (in build directory)
 C_OBJS = $(patsubst src/%.c, $(BUILD_DIR)/%.o, $(C_SOURCES))
 S_OBJS = $(patsubst src/%.s, $(BUILD_DIR)/%.o, $(S_SOURCES))
 ASM_OBJS = $(patsubst src/%.asm, $(BUILD_DIR)/%.o, $(ASM_SOURCES))
 
-OBJS = $(S_OBJS) $(ASM_OBJS) $(C_OBJS)
+OBJS = $(S_OBJS) $(ASM_OBJS) $(C_OBJS) $(ZIG_OBJS)
 
 # Default target
 .DEFAULT_GOAL := help
@@ -94,6 +96,11 @@ $(BUILD_DIR)/%.o: src/%.asm | $(BUILD_DIR)
 	@mkdir -p $(dir $@)
 	@echo "AS $<"
 	@$(AS) -f elf32 $< -o $@
+
+$(BUILD_DIR)/%.o: src/%.zig | $(BUILD_DIR)
+	@mkdir -p $(dir $@)
+	@echo "ZIG $<"
+	@zig build-obj $< -femit-bin=$@ -target x86-freestanding-none -O ReleaseSafe
 
 # Link kernel binary
 $(KERNEL_BIN): $(OBJS) | $(OUTPUT_DIR)

--- a/src/include/ansi.h
+++ b/src/include/ansi.h
@@ -1,0 +1,8 @@
+#ifndef ANSI_H
+#define ANSI_H
+
+#include <stdint.h>
+
+void ansi_process_char(uint8_t c);
+
+#endif

--- a/src/include/terminal.h
+++ b/src/include/terminal.h
@@ -26,6 +26,7 @@ enum vga_color {
 void terminal_initialize(void);
 void terminal_setcolor(uint8_t color);
 void terminal_putchar(char c);
+void terminal_putchar_raw(char c);
 void terminal_write(const char* data, size_t size);
 void terminal_writestring(const char* data);
 void terminal_backspace(void);

--- a/src/kernel/ainsi.zig
+++ b/src/kernel/ainsi.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+
+extern fn terminal_putchar_raw(c: u8) void;
+extern fn terminal_setcolor(color: u8) void;
+extern fn terminal_clear() void;
+
+const DEFAULT_COLOR: u8 = 0x07;
+
+const State = union(enum) {
+    normal,
+    escape,
+    bracket: u16,
+};
+
+var current_state: State = .normal;
+
+export fn ansi_process_char(c: u8) void {
+    switch (current_state) {
+        .normal => {
+            if (c == '\x1b') {
+                current_state = .escape;
+            } else terminal_putchar_raw(c);
+        },
+        .escape => {
+            if (c == '[') {
+                current_state = .{ .bracket = 0 };
+            } else {
+                current_state = .normal; // abort
+            }
+        },
+        .bracket => |*val| {
+            switch (c) {
+                '0'...'9' => {
+                    const n = c - '0';
+                    val.* = (val.* * 10) + n;
+                },
+                'm' => {
+                    const vga_color = csi_to_vga(val.*);
+                    terminal_setcolor(vga_color);
+                    current_state = .normal;
+                },
+                else => {
+                    current_state = .normal;
+                },
+            }
+        },
+    }
+}
+
+fn csi_to_vga(ansi_code: u16) u8 {
+    return switch (ansi_code) {
+        0 => DEFAULT_COLOR,
+
+        // Foreground
+        30 => 0,
+        31 => 4,
+        32 => 2,
+        33 => 6,
+        34 => 1,
+        35 => 5,
+        36 => 3,
+        37 => 7,
+
+        90 => 8,
+        91 => 12,
+        92 => 10,
+        93 => 14,
+        94 => 9,
+        95 => 13,
+        96 => 11,
+        97 => 15,
+
+        else => DEFAULT_COLOR,
+    };
+}

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -30,6 +30,7 @@ void kernel_main(void) {
     terminal_writestring("System ready.\n\n");
     sleep(1000);
     terminal_clear();
+    terminal_writestring("\x1b[96m");
     terminal_writestring("\n\n\n\n\n\n\n                                      X                 \n");
     terminal_writestring("                                     XXX                \n");
     terminal_writestring("                                    XXXXX               \n");
@@ -39,6 +40,7 @@ void kernel_main(void) {
     terminal_writestring("                                XXXXXX  XXXXX           \n");
     terminal_writestring("                               XXXXXX    XXXXX          \n");
     terminal_writestring("                              XXXXXX      XXXXX         \n\n");
+    terminal_writestring("\x1b[0m");
     terminal_writestring("                            Auri-Os - Kernel v0.2\n\n");
     sleep(2000);
     keyboard_init();

--- a/src/kernel/terminal.c
+++ b/src/kernel/terminal.c
@@ -1,5 +1,7 @@
 #include "../include/terminal.h"
 #include "../include/string.h"
+#include "../include/ansi.h"
+#include <stdint.h>
 
 #define VGA_WIDTH 80
 #define VGA_HEIGHT 25
@@ -50,7 +52,12 @@ static void terminal_scroll(void) {
     }
 }
 
+
 void terminal_putchar(char c) {
+  ansi_process_char((uint8_t)c);
+}
+
+void terminal_putchar_raw(char c) {
     if (c == '\n') {
         terminal_column = 0;
         if (++terminal_row == VGA_HEIGHT) {


### PR DESCRIPTION
This pull request adds support for processing ANSI escape sequences (specifically color codes) in the kernel terminal output. It introduces a new Zig-based ANSI parser, updates the build system to support Zig source files, and modifies the terminal output functions to route characters through the ANSI processor. Additionally, the kernel boot message now uses colored output.

**ANSI escape sequence support:**

* Added a new Zig module `ainsi.zig` implementing an ANSI escape sequence parser, which processes characters and applies color changes to the terminal using VGA color codes.
* Introduced a new header file `ansi.h` and function `ansi_process_char` to expose ANSI processing to C code.

**Build system updates:**

* Updated `Makefile` to detect `.zig` source files, compile them with Zig, and link the resulting object files into the kernel build. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R36-R44) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R100-R104)

**Terminal and kernel integration:**

* Modified `terminal_putchar` in `terminal.c` to route characters through `ansi_process_char`, and added `terminal_putchar_raw` for direct character output. [[1]](diffhunk://#diff-c35418675c7c156a41fe5f0e3b3c9b155c346121f0a176838a4537bcaab02540R55-R60) [[2]](diffhunk://#diff-20a60c00e69b6e51b65e4819a89ae9433d4b17c2ec01b122c774ab3246f16f33R29) [[3]](diffhunk://#diff-c35418675c7c156a41fe5f0e3b3c9b155c346121f0a176838a4537bcaab02540R3-R4)
* Updated the kernel boot sequence to output colored text using ANSI escape sequences.