### PR TITLE
Implement logging system for COM port and boot sequence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,12 +132,12 @@ iso: $(KERNEL_BIN)
 # Run in QEMU (x86_64)
 run: iso
 	@echo "Starting QEMU (x86_64)..."
-	@qemu-system-x86_64 -cdrom $(ISO) -m 512M -boot d -vga std
+	@qemu-system-x86_64 -cdrom $(ISO) -m 512M -boot d -vga std -serial stdio
 
 # Run in QEMU (i386)
 run32: iso
 	@echo "Starting QEMU (i386)..."
-	@qemu-system-i386 -cdrom $(ISO) -m 512M -boot d -vga std
+	@qemu-system-i386 -cdrom $(ISO) -m 512M -boot d -vga std -serial stdio
 
 # Run kernel directly on macOS (without ISO)
 run-mac: $(KERNEL_BIN)

--- a/src/cpu/gdt.c
+++ b/src/cpu/gdt.c
@@ -1,4 +1,5 @@
 #include "../include/gdt.h"
+#include "../include/log.h"
 
 #define GDT_ENTRY_COUNT 5
 
@@ -32,4 +33,5 @@ void gdt_init()
     gp.base = (uint32_t)&gdt;
 
     gdt_flush((uint32_t)&gp);
+    KINFO("[GDT] Initialized succesfully");
 }

--- a/src/cpu/idt.c
+++ b/src/cpu/idt.c
@@ -1,5 +1,6 @@
 #include "../include/idt.h"
 #include "../include/isr.h"
+#include "../include/log.h"
 
 #define IDT_ENTRY_COUNT 256
 
@@ -79,4 +80,5 @@ void idt_init(void)
     idt_set_gate(47, (uint32_t)irq15, 0x08, 0x8E);
 
     idt_flush((uint32_t)&idtp);
+    KINFO("[IDT] Gates configured and loaded");
 }

--- a/src/cpu/isr.c
+++ b/src/cpu/isr.c
@@ -1,5 +1,6 @@
 #include "../include/isr.h"
 #include "../include/terminal.h"
+#include "../include/log.h"
 
 static const char *exception_messages[32] = {
     "Division By Zero",
@@ -42,7 +43,7 @@ void isr_handler(registers_t *regs)
         terminal_writestring("EXCEPTION: ");
         terminal_writestring(exception_messages[regs->int_no]);
         terminal_writestring("\n");
-
+        KPANIC(exception_messages[regs->int_no]);
         for (;;) {
           asm volatile("cli; hlt");
         };

--- a/src/cpu/pic.c
+++ b/src/cpu/pic.c
@@ -1,5 +1,6 @@
 #include "../include/pic.h"
 #include "../include/io.h"
+#include "../include/log.h"
 
 #define PIC1_COMMAND 0x20
 #define PIC1_DATA    0x21
@@ -30,4 +31,5 @@ void pic_remap(void)
 
     outb(PIC1_DATA, 0xFF);
     outb(PIC2_DATA, 0xFF);
+    KINFO("[PIC] IRQs remapped to 32-47");
 }

--- a/src/drivers/keyboard.c
+++ b/src/drivers/keyboard.c
@@ -3,6 +3,7 @@
 #include "../include/io.h"
 #include "../include/terminal.h"
 #include "../include/shell.h"
+#include "../include/log.h"
 
 static char scancode_to_ascii[128] = {
     0, 0, '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', 0,
@@ -63,4 +64,5 @@ void keyboard_init(void)
     uint8_t mask = inb(0x21);
     mask &= ~0x02;
     outb(0x21, mask);
+    KINFO("[KBD] PS/2 Keyboard driver active");
 }

--- a/src/drivers/serial.c
+++ b/src/drivers/serial.c
@@ -1,0 +1,30 @@
+#include "../include/serial.h"
+#include "../include/io.h"
+
+#define SERIAL_PORT 0x3F8
+
+void serial_init(void) {
+  outb(SERIAL_PORT + 1, 0x00);
+  outb(SERIAL_PORT + 3, 0x80);
+  outb(SERIAL_PORT + 0, 0x03);
+  outb(SERIAL_PORT + 1, 0x00);
+  outb(SERIAL_PORT + 3, 0x03);
+  outb(SERIAL_PORT + 2, 0xC7);
+  outb(SERIAL_PORT + 4, 0x0B);
+}
+
+static int serial_is_transmit_empty(void) {
+  return inb(SERIAL_PORT + 5) & 0x20;
+}
+
+void serial_write_char(char c) {
+  while (serial_is_transmit_empty() == 0)
+    ;
+  outb(SERIAL_PORT, c);
+}
+
+void serial_write_string(const char *str) {
+  for (int i = 0; str[i] != '\0'; i++) {
+    serial_write_char(str[i]);
+  }
+}

--- a/src/drivers/timer.c
+++ b/src/drivers/timer.c
@@ -1,6 +1,7 @@
 #include "../include/timer.h"
 #include "../include/isr.h"
 #include "../include/io.h"
+#include "../include/log.h"
 #include <stdint.h>
 
 static uint32_t tick = 0;
@@ -26,6 +27,7 @@ void timer_init(uint32_t freq)
     uint8_t mask = inb(0x21);
     mask &= ~0x01;
     outb(0x21, mask);
+    KINFO("[PIT] Programmable Interval Timer configured");
 }
 
 void sleep(uint32_t ms)

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -7,5 +7,6 @@ void klog(const char *level, const char *msg);
 #define KWARN(msg) klog("WARN", msg)
 #define KERR(msg) klog("ERROR", msg)
 #define KDEBUG(msg) klog("DEBUG", msg)
+#define KPANIC(msg) klog("PANIC", msg)
 
 #endif

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -1,0 +1,11 @@
+#ifndef LOG_H
+#define LOG_H
+
+void klog(const char *level, const char *msg);
+
+#define KINFO(msg) klog("INFO", msg)
+#define KWARN(msg) klog("WARN", msg)
+#define KERR(msg) klog("ERROR", msg)
+#define KDEBUG(msg) klog("DEBUG", msg)
+
+#endif

--- a/src/include/serial.h
+++ b/src/include/serial.h
@@ -1,0 +1,8 @@
+#ifndef SERIAL_H
+#define SERIAL_H
+
+void serial_init(void);
+void serial_write_string(const char *str);
+void serial_write_char(char c);
+
+#endif

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -6,8 +6,12 @@
 #include "../include/pic.h"
 #include "../include/shell.h"
 #include "../include/timer.h"
+#include "../include/serial.h"
+#include "../include/log.h"
 
 void kernel_main(void) {
+    serial_init();
+    KINFO("[KRN] Starting AuriOS boot sequence...");
     gdt_init();
     pic_remap();
     idt_init();
@@ -46,6 +50,7 @@ void kernel_main(void) {
     keyboard_init();
     terminal_clear();
     shell_init();
+    KINFO("[KRN] Boot sequence complete. System ready.");
 
     for (;;) {
         asm volatile("hlt");

--- a/src/kernel/log.c
+++ b/src/kernel/log.c
@@ -1,0 +1,11 @@
+#include "../include/log.h"
+#include "../include/serial.h"
+
+void klog(const char *level, const char *msg) {
+  serial_write_char('[');
+  serial_write_string(level);
+  serial_write_string("] ");
+  serial_write_string(msg);
+  serial_write_char('\n');
+  serial_write_char('\r');
+}

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -1,6 +1,7 @@
 #include "../include/memory.h"
 #include "../include/string.h"
 #include "../include/memory.h"
+#include "../include/log.h"
 #include <stdint.h>
 
 typedef struct block_header {
@@ -23,6 +24,7 @@ void memory_init(void) {
     head->size = 1024 * 1024;
     head->free = 1;
     head->next = NULL;
+    KINFO("[MEM] Initial heap mapped");
 }
 
 #pragma GCC diagnostic pop


### PR DESCRIPTION
This pull request introduces a kernel-wide logging system with serial output and integrates informational log messages across major subsystems. It also improves QEMU run scripts to support serial output, which is essential for kernel debugging. The most important changes are summarized below:

**Logging Infrastructure and Serial Output:**

* Added a new logging interface with macros (`KINFO`, `KWARN`, `KERR`, `KDEBUG`, `KPANIC`) and a `klog` implementation that writes log messages to the serial port (`src/include/log.h`, `src/kernel/log.c`). [[1]](diffhunk://#diff-434252b430af9f93bcb6c312072876668a60d2421e96a02cf1046badbb59df0eR1-R12) [[2]](diffhunk://#diff-44a9e8396c26a168b2af64e402b67cadbd67a9aa6f323c209a7aaa97c55068ffR1-R11)
* Implemented a basic serial driver for output, providing `serial_init`, `serial_write_string`, and `serial_write_char` (`src/drivers/serial.c`, `src/include/serial.h`). [[1]](diffhunk://#diff-e2937c3b56e9dd59a635c821e72ea1806d47cb303d46aaa578ee44aa452509d8R1-R30) [[2]](diffhunk://#diff-3009109b9a2b5388d53d640a8d90c36d883161adde051a86d3635bd56e2908d6R1-R8)
* Integrated serial initialization and early boot log messages into the kernel entry point (`src/kernel/kernel.c`). [[1]](diffhunk://#diff-b64aca7470d79a105982568df1d4efa1122898afb01f59ee96a785069e2966d5R9-R14) [[2]](diffhunk://#diff-b64aca7470d79a105982568df1d4efa1122898afb01f59ee96a785069e2966d5R53)

**Subsystem Logging Integration:**

* Added log statements to initialization routines for GDT, IDT, PIC, timer, keyboard, and heap memory, providing clear status updates during boot and device setup (`src/cpu/gdt.c`, `src/cpu/idt.c`, `src/cpu/pic.c`, `src/drivers/timer.c`, `src/drivers/keyboard.c`, `src/lib/memory.c`). [[1]](diffhunk://#diff-30e41b58ed44c6c7a7a885254174023b01499cd48180e9a027b05a4788474aa4R2) [[2]](diffhunk://#diff-30e41b58ed44c6c7a7a885254174023b01499cd48180e9a027b05a4788474aa4R36) [[3]](diffhunk://#diff-b0f5104843ba750f9df4477cd851d177403402bf1d05a29975ba273a2358e279R3) [[4]](diffhunk://#diff-b0f5104843ba750f9df4477cd851d177403402bf1d05a29975ba273a2358e279R83) [[5]](diffhunk://#diff-f08bd14a676fd778297f1c683d111e1267b495b3b241f8fd80bb7bc987ac32e5R3) [[6]](diffhunk://#diff-f08bd14a676fd778297f1c683d111e1267b495b3b241f8fd80bb7bc987ac32e5R34) [[7]](diffhunk://#diff-c0982419544b44b1e3350736fa85fec4eae3cc018acac10117d5bf1ce4da6c39R4) [[8]](diffhunk://#diff-c0982419544b44b1e3350736fa85fec4eae3cc018acac10117d5bf1ce4da6c39R30) [[9]](diffhunk://#diff-e0d449fe88a1a2ed28ec2ed0551631b9edd6b9cd04c2a423dfd501c678024eb0R6) [[10]](diffhunk://#diff-e0d449fe88a1a2ed28ec2ed0551631b9edd6b9cd04c2a423dfd501c678024eb0R67) [[11]](diffhunk://#diff-8b7fe32aacf90742af034330135442a8e399f643e34f32a964b4f0fd94894978R4) [[12]](diffhunk://#diff-8b7fe32aacf90742af034330135442a8e399f643e34f32a964b4f0fd94894978R27)
* Enhanced exception handling to log critical errors using `KPANIC` in the ISR handler (`src/cpu/isr.c`). [[1]](diffhunk://#diff-7ea7a2082fdc0259a07d1cde5b6d535f99d43f63919871c2e2496236f247168fR3) [[2]](diffhunk://#diff-7ea7a2082fdc0259a07d1cde5b6d535f99d43f63919871c2e2496236f247168fL45-R46)

**Development and Debugging Support:**

* Updated QEMU run commands in the `Makefile` to include `-serial stdio`, enabling serial output to be visible in the host terminal for easier debugging.

These changes collectively add a robust logging mechanism, improve kernel visibility during boot and runtime, and enhance the developer experience for debugging and monitoring kernel activity.

<img width="1822" height="270" alt="image" src="https://github.com/user-attachments/assets/42994e3b-e182-4b61-bfb4-4dcfe08b6664" />


