### PR TITLE
Modified binutils and gcc install script to be easier to manage and configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 output/
 iso/
+.environment/
 
 # Generated files
 *.o

--- a/docs/install_scripts/install.sh
+++ b/docs/install_scripts/install.sh
@@ -1,25 +1,56 @@
+#!/bin/sh
+set -e
+readonly BINUTILS_VERSION="2.41"
+readonly GCC_VERSION="13.2.0"
+readonly THREADS=$(nproc)
+readonly PREFIX="$PWD/.environment"
+
 echo "[!] Installing cross compiler for i686-elf"
-mkdir -p ~/opt/cross
-cd ~/opt/cross
-wget https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.gz
-wget https://ftp.gnu.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.gz
-tar -xf binutils-2.41.tar.gz
-tar -xf gcc-13.2.0.tar.gz
-mkdir build-binutils build-gcc
+mkdir -p "$PREFIX/opt"
+cd "$PREFIX/opt"
+if [ ! -d binutils ]; then
+	wget -O binutils.tar.gz "https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.gz"
+	tar -xf binutils.tar.gz
+	rm binutils.tar.gz
+	mv binutils* binutils
+fi
+if [ ! -d gcc ]; then
+	wget -O gcc.tar.gz "https://ftp.gnu.org/gnu/gcc/gcc-13.2.0/gcc-$GCC_VERSION.tar.gz"
+	tar -xf gcc.tar.gz
+	rm gcc.tar.gz
+	mv gcc* gcc
+fi
+
 echo "[!] Building and installing binutils"
-cd build-binutils
-../binutils-2.41/configure --target=i686-elf --prefix=$HOME/opt/cross --with-sysroot --disable-nls --disable-werror
-make -j$(nproc)
+cd binutils
+mkdir -p build
+cd build
+if [ ! -f Makefile ]; then
+	../configure --target=i686-elf --prefix="$PREFIX" --with-sysroot --disable-nls --disable-werror
+fi
+make -j$THREADS
 make install
-cd ..
+
+cd "$PREFIX/opt"
+
 echo "[!] Building and installing GCC"
-cd build-gcc
-../gcc-13.2.0/configure --target=i686-elf --prefix=$HOME/opt/cross --disable-nls --enable-languages=c,c++ --without-headers
-make all-gcc -j$(nproc)
-make all-target-libgcc -j$(nproc)
+cd gcc
+mkdir -p build
+cd build
+if [ ! -f Makefile ]; then
+	../configure --target=i686-elf --prefix="$PREFIX" --disable-nls --enable-languages=c,c++ --without-headers
+fi
+make all-gcc -j$THREADS
+make all-target-libgcc -j$THREADS
 make install-gcc
 make install-target-libgcc
-cd ..
+
+cd "$PREFIX"
+
 echo "[!] Cross compiler installed successfully"
-echo 'export PATH="$HOME/opt/cross/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
+
+cat > ./activate << EOF
+export PATH="$PREFIX/bin:\$PATH"
+EOF
+
+printf "\nactivate with: \n\t. $PREFIX/activate\n"


### PR DESCRIPTION
I modified `docs/install_scripts/install.sh` so
* It does not download `gcc` and `binutils` sources everytime
* It uses version variables so it is easier to upgrade tools
* It does not modify user `.bashrc` file that may was overkill for a single project