### PR TITLE
Fix: Critical string bugs + memory allocator improvements

### DIFF
--- a/src/include/string.h
+++ b/src/include/string.h
@@ -5,8 +5,9 @@
 
 size_t strlen(const char* str);
 int strcmp(const char *s1, const char *s2);
-int	strcat(char *dest, char *src);
-char *strncat(char *dest, char *src, unsigned int nb);
+int	strncmp(const char *s1, const char *s2, unsigned int n);
+char *strcat(char *dest, const char *src);
+char *strncat(char *dest, const char *src, unsigned int nb);
 int str_is_uppercase(char *str);
 int str_is_lowercase(char *str);
 char *strupcase(char *str);

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -1,6 +1,5 @@
 #include "../include/memory.h"
 #include "../include/string.h"
-#include "../include/memory.h"
 #include <stdint.h>
 
 typedef struct block_header {
@@ -101,7 +100,7 @@ void *memccpy(void *dest, const void *src, int c, size_t n) {
 // Duplicate a string pointer
 char *strdup(const char *src)
 {
-	char *cpy = malloc(sizeof(char) * (strlen(src) + 1));
+	char *cpy = malloc(strlen(src) + 1);
 	if (cpy == NULL)
 		return NULL;
 	strcpy(cpy, src);
@@ -115,6 +114,14 @@ void *malloc(size_t size)
 
     while (block) {
         if (block->free && block->size >= size) {
+            if (block->size > size + HEADER_SIZE + 16) {
+                block_header_t *new_block = (block_header_t *)((uint8_t *)block + HEADER_SIZE + size);
+                new_block->size = block->size - size - HEADER_SIZE;
+                new_block->free = 1;
+                new_block->next = block->next;
+                block->size = size;
+                block->next = new_block;
+            }
             block->free = 0;
             return (void *)((uint8_t *)block + HEADER_SIZE);
         }
@@ -131,6 +138,18 @@ void free(void *ptr)
         return;
 
     block_header_t *block = (block_header_t *)((uint8_t *)ptr - HEADER_SIZE);
-    if (block != 0)
-        block->free = 1;
+    block->free = 1;
+
+    if (block->next && block->next->free) {
+        block->size += HEADER_SIZE + block->next->size;
+        block->next = block->next->next;
+    }
+
+    block_header_t *prev = head;
+    while (prev && prev->next != block)
+        prev = prev->next;
+    if (prev && prev->free) {
+        prev->size += HEADER_SIZE + block->size;
+        prev->next = block->next;
+    }
 }

--- a/src/lib/string.c
+++ b/src/lib/string.c
@@ -19,7 +19,7 @@ int strcmp(const char *s1, const char *s2)
 }
 
 // Compare the first n byte of two string between them
-int	strncmp(char *s1, char *s2, unsigned int n)
+int	strncmp(const char *s1, const char *s2, unsigned int n)
 {
 	unsigned int i = 0;
 	while (s1[i] == s2[i] && s2[i] != '\0' && i < n - 1)
@@ -32,7 +32,7 @@ int	strncmp(char *s1, char *s2, unsigned int n)
 }
 
 // Catenate string from src to dest
-int	strcat(char *dest, char *src)
+char *strcat(char *dest, const char *src)
 {
 	unsigned int a = 0;
 	unsigned int b = 0;
@@ -44,11 +44,12 @@ int	strcat(char *dest, char *src)
 		dest[a + b] = src[b];
 		b++;
 	}
-	return (*dest);
+	dest[a + b] = '\0';
+	return (dest);
 }
 
 // Catenate the first n bytes from a src string to dest 
-char *strncat(char *dest, char *src, unsigned int nb)
+char *strncat(char *dest, const char *src, unsigned int nb)
 {
 	unsigned int i = 0;
 	unsigned int j = 0;
@@ -71,7 +72,7 @@ int str_is_uppercase(char *str)
 	int	i = 0;
 	while (str[i] != '\0')
 	{
-		if (str[i] < 'A' || (str[i] > 'a' && str[i] < 'z') || str[i] > 'Z')
+		if (str[i] >= 'a' && str[i] <= 'z')
 			return (0);
 		i++;
 	}
@@ -84,7 +85,7 @@ int str_is_lowercase(char *str)
 	int	i = 0;
 	while (str[i] != '\0')
 	{
-		if (str[i] < 'a' || (str[i] > 'A' && str[i] < 'Z') || str[i] > 'z')
+		if (str[i] >= 'A' && str[i] <= 'Z')
 			return (0);
 		i++;
 	}


### PR DESCRIPTION
### `string.c` / `string.h`
- **`strcat`** : Fixed return type `int` → `char*`, added missing null-termination, `src` now `const`
- **`str_is_uppercase` / `str_is_lowercase`** : Completely rewritten broken logic (incorrect inverse checks)
- **`strncat` / `strncmp`** : Added `const` to parameters for const-correctness
- Updated function prototypes in header

### `memory.c`
- Removed duplicate include
- **`malloc`** : Added **block splitting** - prevents memory waste when a free block is larger than requested
- **`free`** : Added **coalescing** - merges adjacent free blocks to reduce fragmentation
- **`strdup`** : Simplified allocation calculation (removed unnecessary `sizeof(char) * ...`)
