### PR TITLE
fix: include missing headers in kernel.c

### DIFF
--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -8,7 +8,8 @@
 #include "../include/timer.h"
 #include "../include/integer.h"
 #include "../include/string.h"
-#include "../include/timer.h" 
+#include "../include/serial.h"
+#include "../include/log.h" 
 
 static void set_cursor_ansi(int x, int y) {
     char buf[16];


### PR DESCRIPTION
Removing duplicated include of "timer" header.

Added serial & log header to fix compilation errors : 

`src/kernel/kernel.c: In function 'kernel_main':
src/kernel/kernel.c:98:5: error: implicit declaration of function 'serial_init' [-Wimplicit-function-declaration]
   98 |     serial_init();
      |     ^~~~~~~~~~~
src/kernel/kernel.c:99:5: error: implicit declaration of function 'KINFO' [-Wimplicit-function-declaration]
   99 |     KINFO("[KRN] Starting AuriOS boot sequence...");
      |     ^~~~~
make: *** [build/kernel/kernel.o] Error 1`