### PR TITLE
Fix: Hardware abstraction leak between keyboard and PIC

### DIFF
--- a/src/cpu/pic.c
+++ b/src/cpu/pic.c
@@ -42,7 +42,7 @@ void pic_unmask_irq(uint8_t irqline)
     // Si l'IRQ est entre 0-7, PIC Master (0x21)
     // else, 8-15, PIC Slave (0xA1)
     if (irqline < 8) {
-        port = PIC1_DATA
+        port = PIC1_DATA;
     } else {
         port = PIC2_DATA;
         irqline -= 8;

--- a/src/cpu/pic.c
+++ b/src/cpu/pic.c
@@ -33,3 +33,21 @@ void pic_remap(void)
     outb(PIC2_DATA, 0xFF);
     KINFO("[PIC] IRQs remapped to 32-47");
 }
+
+void pic_unmask_irq(uint8_t irqline)
+{
+    uint16_t port;
+    uint8_t value;
+
+    // Si l'IRQ est entre 0-7, PIC Master (0x21)
+    // else, 8-15, PIC Slave (0xA1)
+    if (irqline < 8) {
+        port = PIC1_DATA
+    } else {
+        port = PIC2_DATA;
+        irqline -= 8;
+    }
+
+    value = inb(port) & ~(1 << irqline);
+    outb(port, value);
+}

--- a/src/drivers/keyboard.c
+++ b/src/drivers/keyboard.c
@@ -79,8 +79,6 @@ void keyboard_callback(registers_t *regs)
 void keyboard_init(void)
 {
     irq_register_handler(1, keyboard_callback);
-    uint8_t mask = inb(0x21);
-    mask &= ~0x02;
-    outb(0x21, mask);
+    pic_unmask_irq(1);
     KINFO("[KBD] PS/2 Keyboard driver active");
 }

--- a/src/drivers/keyboard.c
+++ b/src/drivers/keyboard.c
@@ -4,6 +4,7 @@
 #include "../include/terminal.h"
 #include "../include/shell.h"
 #include "../include/log.h"
+#include "../include/pic.h"
 
 static char scancode_to_ascii[128] = {
     0, 0, '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', 0,

--- a/src/include/pic.h
+++ b/src/include/pic.h
@@ -2,5 +2,6 @@
 #define PIC_H
 
 void pic_remap(void);
+void pic_unmask_irq(uint8_t irqline);
 
 #endif

--- a/src/include/pic.h
+++ b/src/include/pic.h
@@ -1,6 +1,6 @@
 #ifndef PIC_H
 #define PIC_H
-
+#include <stdint.h>
 void pic_remap(void);
 void pic_unmask_irq(uint8_t irqline);
 


### PR DESCRIPTION
Hey 

I was exploring the codebase and noticed a small architectural issue with the keyboard driver, so I put together this PR to fix it.

## Problem
The `keyboard_init` function was directly manipulating the PIC data port (`0x21`) to unmask IRQ 1. This is a severe architectural leak: peripheral drivers should not be aware of the internal CPU interrupt controller layout. This tight coupling would break the driver if we ever port to APIC or another architecture.

## Solution
Introduced a proper hardware abstraction API `pic_unmask_irq(uint8_t irqline)` in `pic.c`. The keyboard driver now cleanly requests IRQ 1 without hardcoding x86-specific I/O ports.

## Stability & Impact
- **Memory footprint / Stack:** No changes.
- **Side effects:** Replaced direct binary masking with an isolated API call. Ensures safe IRQ management.
- **Validation:** Tested successfully on QEMU/VirtualBox VM (x86). Keyboard input functions perfectly without regressions. 

## Screenshot
<img width="726" height="398" alt="image" src="https://github.com/user-attachments/assets/cc7b93fd-f1d4-4f09-ae78-f80006f38da9" />




Let me know what you think or if you want me to change anything. Thanks for taking the time to review!