### PR TITLE
Fix/shell cmd parser

### DIFF
--- a/src/include/string.h
+++ b/src/include/string.h
@@ -12,5 +12,5 @@ int str_is_lowercase(char *str);
 char *strupcase(char *str);
 char *strlowcase(char *str);
 char *strcpy(char *dest, const char *src);
-
+char *str_trim(char *str);
 #endif

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -15,9 +15,8 @@ void shell_init(void) {
 
 static void shell_execute(char* cmd)
 {
-    int i = 0;
-    while (cmd[i] == ' ') i++;
-    if (cmd[i] == '\0') return;
+    cmd = str_trim(cmd);
+    if (cmd == NULL || cmd[0] == '\0') return;
 
     if (strcmp(cmd, "help") == 0) {
         terminal_writestring("\nhelp - show this command\n");

--- a/src/lib/string.c
+++ b/src/lib/string.c
@@ -50,7 +50,7 @@ int	strcat(char *dest, char *src)
 // Catenate the first n bytes from a src string to dest 
 char *strncat(char *dest, char *src, unsigned int nb)
 {
-	unsigned int i = 0;
+unsigned int i = 0;
 	unsigned int j = 0;
 
 	while (dest[i] != '\0')
@@ -127,3 +127,24 @@ char *strcpy(char *dest, const char *src) {
     dest[i] = 0;
     return(dest);
 }
+
+char *str_trim(char *str)
+{
+    char *end;
+
+    if (str == NULL)
+        return NULL;
+    
+    while (*str == ' ' || *str == '\t'){
+        str++;
+    }
+    if (*str == '\0') {
+        return str;
+    }
+    end = str + strlen(str) - 1;
+    while (end > str && (*end == ' ' || *end == '\t')) {
+        *end = '\0';
+        end--;
+    }
+    return str;
+} 


### PR DESCRIPTION
**Fixes #49**
Hello (again), 

So, here is a fix for [`Shell parsing too strict #49`](https://github.com/Auri-OS/AuriOS/issues/49).
I just added a `str_trim` function who trims the string by removing tabs, and space from the inserted command.

It's working fine, but i would like a review since i'm still a begginer in C ^^"  

Screenshot:

<img width="976" height="642" alt="image" src="https://github.com/user-attachments/assets/65ca4edc-0459-49e3-a8cc-263c3cf8e618" />


