### PR TITLE
Fix/cmd l reseting buffer position

### DIFF
--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -75,6 +75,7 @@ void shell_handle_key(char c)
 {
     if (c == 0x0C) {
         terminal_clear();
+		buffer_pos = 0;
         shell_init();
         return;
     }


### PR DESCRIPTION
Reseting the buffer pos to prevent this bug : 

<img width="904" height="541" alt="image" src="https://github.com/user-attachments/assets/5921b19c-c29d-4d98-98f1-f4c5f32ebe4e" />
