### PR TITLE
#42 Add Physical Memory Manager (PMM)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ AS = nasm
 C_SOURCES = $(wildcard src/kernel/*.c) $(wildcard src/cpu/*.c) $(wildcard src/lib/*.c) $(wildcard src/drivers/*.c)
 S_SOURCES = $(wildcard src/boot/*.s)
 ASM_SOURCES = $(wildcard src/cpu/*.asm)
-ZIG_SOURCES = $(wildcard src/kernel/*.zig)
+ZIG_SOURCES = $(wildcard src/kernel/*.zig) $(wildcard src/mm/*.zig)
 ZIG_OBJS = $(patsubst src/%.zig, $(BUILD_DIR)/%.o, $(ZIG_SOURCES))
 
 # Object files (in build directory)

--- a/src/boot/loader.s
+++ b/src/boot/loader.s
@@ -24,9 +24,15 @@ loader:
     push 0
     popf
 
+    ;push kernel_main args
+    push ebx
+    push eax
+
     ; call kernel.c     */
     call kernel_main
-
+    
+    ; clean stack
+    add esp, 8
 .loop:
     hlt
     jmp .loop

--- a/src/include/mm.h
+++ b/src/include/mm.h
@@ -1,0 +1,15 @@
+#ifndef MM_H
+#define MM_H
+
+#include <stdint.h>
+
+extern char kernel_end;
+
+extern void pmm_init(uint32_t max_ram_addr, uint32_t kernel_end_addr);
+extern void pmm_mark_region_free(uint32_t base, uint32_t size);
+extern void pmm_mark_region_used(uint32_t base, uint32_t size);
+extern uint32_t pmm_alloc_frame(void);
+extern uint32_t pmm_free_frame(uint32_t phys_addr);
+extern void pmm_dump_bitmap(uint32_t bytes_to_dump);
+
+#endif

--- a/src/include/multiboot.h
+++ b/src/include/multiboot.h
@@ -33,4 +33,16 @@ typedef struct multiboot_info {
     uint8_t  framebuffer_type;
 } __attribute__((packed)) multiboot_info_t;
 
+#define MULTIBOOT_MEMORY_AVAILABLE 1
+#define MULTIBOOT_BOOTLOADER_MAGIC 0x2BADB002
+
+typedef struct multiboot_memory_map {
+    uint32_t size;
+    uint32_t base_addr_low;
+    uint32_t base_addr_high;
+    uint32_t length_low;
+    uint32_t length_high;
+    uint32_t type;
+} __attribute__((packed)) multiboot_memory_map_t;
+
 #endif

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -11,6 +11,7 @@
 #include "../include/serial.h"
 #include "../include/log.h" 
 #include "../include/multiboot.h"
+#include "../include/mm.h"
 
 static void set_cursor_ansi(int x, int y) {
     char buf[16];
@@ -96,25 +97,37 @@ void animate_logo(void) {
     sleep(1000);
 }
 
-void check_mem(multiboot_info_t *mboot_ptr) {
-    if (mboot_ptr->flags & (1 << 6)) {
-      multiboot_memory_map_t *mmap = (multiboot_memory_map_t*) mboot_ptr->mmap_addr;
-      
-      while ((uint32_t)mmap < mboot_ptr->mmap_addr + mboot_ptr->mmap_length) {
-        if (mmap->type == MULTIBOOT_MEMORY_AVAILABLE) {
-          char buf[32];
-          serial_write_string("[MEM] Free zone found: Base=0x");
-          serial_write_string(itoa(mmap->base_addr_low, buf)); 
-          serial_write_string(" Size=");
-          serial_write_string(itoa(mmap->length_low, buf));
-          serial_write_string(" bytes\n\r");
+void init_mem(multiboot_info_t *mboot_ptr) {
+    if (mboot_ptr->flags & (1 << 6)) { 
+        multiboot_memory_map_t* mmap = (multiboot_memory_map_t*) mboot_ptr->mmap_addr;
+        
+        uint32_t max_ram_addr = 0;
+        multiboot_memory_map_t* temp_mmap = mmap;
+        while ((uint32_t)temp_mmap < mboot_ptr->mmap_addr + mboot_ptr->mmap_length) {
+            uint32_t zone_end = temp_mmap->base_addr_low + temp_mmap->length_low;
+            if (zone_end > max_ram_addr) {
+                max_ram_addr = zone_end;
+            }
+            temp_mmap = (multiboot_memory_map_t*) ((uint32_t)temp_mmap + temp_mmap->size + sizeof(temp_mmap->size));
         }
-        mmap = (multiboot_memory_map_t*) ((uint32_t)mmap + mmap->size + sizeof(mmap->size));
-      }
+
+        uint32_t kernel_end_addr = (uint32_t)&kernel_end;
+        pmm_init(max_ram_addr, kernel_end_addr);
+
+        while ((uint32_t)mmap < mboot_ptr->mmap_addr + mboot_ptr->mmap_length) {
+            if (mmap->type == MULTIBOOT_MEMORY_AVAILABLE) {
+                pmm_mark_region_free(mmap->base_addr_low, mmap->length_low);
+            }
+            mmap = (multiboot_memory_map_t*) ((uint32_t)mmap + mmap->size + sizeof(mmap->size));
+        }
+
+        uint32_t bitmap_size = (max_ram_addr / 4096) / 8;
+        pmm_mark_region_used(0x100000, (kernel_end_addr - 0x100000) + bitmap_size);
+        pmm_mark_region_used(0x0, 4096);
+        KINFO("[PMM] Physical Memory Manager initialized by Zig.");
     } else {
-      KPANIC("No memory map provided by bootloader");
-    }
-}
+        KPANIC("No memory map provided by bootloader!");
+    }}
 
 void kernel_main(uint32_t magic, multiboot_info_t *mboot_ptr) {
     serial_init();
@@ -129,12 +142,12 @@ void kernel_main(uint32_t magic, multiboot_info_t *mboot_ptr) {
     pic_remap();
     idt_init();
     terminal_initialize();
-    memory_init();
     timer_init(1000);
 
     asm volatile("sti");
 
-    check_mem(mboot_ptr);
+    init_mem(mboot_ptr);
+    pmm_dump_bitmap(128);
 
     terminal_writestring("AuriOS Kernel v0.2\n");
     sleep(100);
@@ -155,7 +168,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mboot_ptr) {
     terminal_clear();
     shell_init();
     KINFO("[KRN] Boot sequence complete. System ready.");
-
+  
     for (;;) {
         asm volatile("hlt");
     }

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -10,6 +10,7 @@
 #include "../include/string.h"
 #include "../include/serial.h"
 #include "../include/log.h" 
+#include "../include/multiboot.h"
 
 static void set_cursor_ansi(int x, int y) {
     char buf[16];
@@ -95,8 +96,34 @@ void animate_logo(void) {
     sleep(1000);
 }
 
-void kernel_main(void) {
+void check_mem(multiboot_info_t *mboot_ptr) {
+    if (mboot_ptr->flags & (1 << 6)) {
+      multiboot_memory_map_t *mmap = (multiboot_memory_map_t*) mboot_ptr->mmap_addr;
+      
+      while ((uint32_t)mmap < mboot_ptr->mmap_addr + mboot_ptr->mmap_length) {
+        if (mmap->type == MULTIBOOT_MEMORY_AVAILABLE) {
+          char buf[32];
+          serial_write_string("[MEM] Free zone found: Base=0x");
+          serial_write_string(itoa(mmap->base_addr_low, buf)); 
+          serial_write_string(" Size=");
+          serial_write_string(itoa(mmap->length_low, buf));
+          serial_write_string(" bytes\n\r");
+        }
+        mmap = (multiboot_memory_map_t*) ((uint32_t)mmap + mmap->size + sizeof(mmap->size));
+      }
+    } else {
+      KPANIC("No memory map provided by bootloader");
+    }
+}
+
+void kernel_main(uint32_t magic, multiboot_info_t *mboot_ptr) {
     serial_init();
+
+    if (magic != MULTIBOOT_BOOTLOADER_MAGIC) {
+      KPANIC("Invalid Multiboot magic number");
+      return;
+    }
+    
     KINFO("[KRN] Starting AuriOS boot sequence...");
     gdt_init();
     pic_remap();
@@ -106,6 +133,8 @@ void kernel_main(void) {
     timer_init(1000);
 
     asm volatile("sti");
+
+    check_mem(mboot_ptr);
 
     terminal_writestring("AuriOS Kernel v0.2\n");
     sleep(100);

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -4,6 +4,7 @@
 #include "../include/timer.h"
 #include "../include/integer.h"
 #include "../include/colors.h"
+#include "../include/mm.h"
 
 #define BUFFER_SIZE 256
 #define MAX_CMD_ARGS 16
@@ -177,6 +178,10 @@ static void shell_execute(char* cmd)
         
         if (!skip_newline)
             terminal_writestring("\n");
+    }
+    else if (strcmp(cmd_name, "memdump") == 0) {
+        // for now i print 128 bytes all the time but when args parsings will be set we can just print the size we want
+        pmm_dump_bitmap(128);
     }
     else {
         terminal_writestring("command not found: ");

--- a/src/mm/pmm.zig
+++ b/src/mm/pmm.zig
@@ -1,0 +1,145 @@
+const std = @import("std");
+
+const PAGE_SIZE = 4096;
+
+var bitmap: []u8 = undefined;
+
+extern fn serial_write_char(c: u8) void;
+extern fn serial_write_string(str: [*c]const u8) void;
+
+pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_addr: ?usize) noreturn {
+    _ = msg;
+    _ = error_return_trace;
+    _ = ret_addr;
+
+    while (true) {
+        asm volatile ("cli; hlt");
+    }
+}
+
+fn print_hex(val: usize) void {
+    serial_write_string("0x");
+    var temp = val;
+    var buf: [8]u8 = undefined;
+    var i: usize = 8;
+
+    while (i > 0) {
+        i -= 1;
+        const nibble = @as(u8, @truncate(temp & 0xF));
+        buf[i] = if (nibble < 10) '0' + nibble else 'A' + (nibble - 10);
+        temp >>= 4;
+    }
+
+    for (buf) |c| {
+        serial_write_char(c);
+    }
+}
+
+export fn pmm_dump_bitmap(bytes_to_dump: usize) void {
+    serial_write_string("\r\n=== PMM BITMAP DUMP ===\r\n");
+    serial_write_string("Legend: [#] Used/Reserved  [.] Free\r\n\n");
+
+    const limit = @min(bytes_to_dump, bitmap.len);
+    var i: usize = 0;
+
+    while (i < limit) : (i += 1) {
+        if (i % 8 == 0) {
+            serial_write_string("\r\n");
+            const phys_base = i * 8 * PAGE_SIZE;
+            print_hex(phys_base);
+            serial_write_string(" | ");
+        }
+
+        const byte = bitmap[i];
+        var bit: u8 = 0;
+
+        while (bit < 8) : (bit += 1) {
+            const shift_amount = @as(u3, @intCast(bit));
+            const mask = @as(u8, 1) << shift_amount;
+
+            if ((byte & mask) != 0) {
+                serial_write_char('#');
+            } else {
+                serial_write_char('.');
+            }
+        }
+        serial_write_char(' ');
+    }
+    serial_write_string("\r\n\n=======================\r\n");
+}
+
+export fn pmm_init(max_ram_addr: usize, kernel_end_addr: usize) void {
+    const total_pages = max_ram_addr / PAGE_SIZE;
+    const bitmap_size = total_pages / 8;
+
+    const bitmap_ptr = @as([*]u8, @ptrFromInt(kernel_end_addr));
+    bitmap = bitmap_ptr[0..bitmap_size];
+
+    @memset(bitmap, 0xFF);
+}
+
+export fn pmm_mark_region_free(base: usize, size: usize) void {
+    const start_page = base / PAGE_SIZE;
+    const end_page = (base + size) / PAGE_SIZE;
+
+    var i: usize = start_page;
+    while (i < end_page) : (i += 1) {
+        const byte_idx = i / 8;
+        const bit_idx = @as(u3, @truncate(i % 8));
+
+        bitmap[byte_idx] &= ~(@as(u8, 1) << bit_idx);
+    }
+}
+
+export fn pmm_mark_region_used(base: usize, size: usize) void {
+    const start_page = base / PAGE_SIZE;
+    const end_page = (base + size) / PAGE_SIZE;
+
+    var i: usize = start_page;
+    while (i < end_page) : (i += 1) {
+        const byte_idx = i / 8;
+        const bit_idx = @as(u3, @truncate(i % 8));
+
+        bitmap[byte_idx] |= (@as(u8, 1) << bit_idx);
+    }
+}
+
+/// Finds the first available physical page (frame) in the memory.
+///
+/// How it works:
+/// The entire RAM is represented as an array of bytes (the bitmap).
+/// 1 bit = 1 page (4096 bytes).
+///   - Bit is 1 : Page is USED or RESERVED.
+///   - Bit is 0 : Page is FREE.
+///
+/// Example of a byte in the bitmap: 11101111 (0xEF)
+///   [1] [1] [1] [0] [1] [1] [1] [1]
+///    |   |   |   |   |   |   |   |
+///   p7  p6  p5  p4  p3  p2  p1  p0
+///                ^
+///             Free page
+///
+/// To optimize the search, we don't check bits one by one. We check byte by byte.
+/// If a byte is 0xFF (11111111), it means ALL 8 pages are FULL. We skip it instantly.
+/// If a byte is != 0xFF, it means there is AT LEAST ONE '0' inside. We then scan its bits.
+export fn pmm_alloc_frame() usize {
+    for (bitmap, 0..) |byte, byte_idx| {
+        if (byte != 0xFF) {
+            var bit_idx: u3 = 0;
+            while (bit_idx < 8) : (bit_idx += 1) {
+                const mask = @as(u8, 1) << bit_idx;
+                if ((byte & mask) == 0) {
+                    const page_idx = (byte_idx * 8) + bit_idx;
+                    const phys_addr = page_idx * PAGE_SIZE;
+                    pmm_mark_region_used(phys_addr, PAGE_SIZE);
+                    return phys_addr;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+export fn pmm_free_frame(phys_addr: usize) void {
+    pmm_mark_region_used(phys_addr, PAGE_SIZE);
+}


### PR DESCRIPTION
This pull request introduces a physical memory manager (PMM) written in Zig and integrates it into the kernel. The main changes include adding a new PMM implementation, updating the kernel to initialize and use the PMM based on the Multiboot memory map, and providing a new shell command for dumping the PMM bitmap. These changes lay the groundwork for robust memory management in the OS.

**Memory Management Implementation and Integration:**

* Added a new Zig-based physical memory manager in `src/mm/pmm.zig`, which includes bitmap management, frame allocation/freeing, and region marking functions. The PMM is initialized at kernel boot and provides a bitmap dump utility for debugging.
* Updated the kernel (`kernel.c`) to parse the Multiboot memory map, calculate usable RAM, and initialize the PMM with correct memory regions. The kernel now calls `pmm_init`, marks regions as free/used, and exposes a memory dump at boot.
* Added new header files `mm.h` and updated includes in kernel and shell code to expose PMM functions to C code. [[1]](diffhunk://#diff-4236e9f6c94de2cccb8883067635ed8719f1ecc53d66f8b4ff6bb538e55691bcR1-R15) [[2]](diffhunk://#diff-b64aca7470d79a105982568df1d4efa1122898afb01f59ee96a785069e2966d5R13-R14) [[3]](diffhunk://#diff-86a30a836de2d5968a90cdc168b0c388e1f2d4d5bda8bf43326a005a49b563faR7)

**Bootloader and Multiboot Support:**

* Modified the bootloader and kernel entry to pass Multiboot magic and info structures to `kernel_main`, enabling dynamic memory detection. [[1]](diffhunk://#diff-d359b1525409c5e895c5b8819ffb1719eef8982ebd25cad63835d359b5703efeR27-R35) [[2]](diffhunk://#diff-9ebcf38e3558011e2b611fed4ffe00ed08037607ac36b6a5c7d05c448a1ad6faR36-R47)

**Developer/Debugging Tools:**

* Added a new shell command `memdump` to print the first 128 bytes of the PMM bitmap for debugging memory usage.

**Build System:**

* Updated the `Makefile` to include Zig source files from the new `src/mm` directory.

> [!NOTE]
> Technical description written by copilot


I'm doing this PR to respond to issue #42 as a first step in our implementation of the Memory Management Subsystem