### PR TITLE
fix: Keystrokes during boot sequence leak into the shell buf...

### DIFF
--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -4,6 +4,7 @@
 #include "../include/timer.h"
 #include "../include/integer.h"
 #include "../include/colors.h"
+#include "../include/memory.h"
 
 #define BUFFER_SIZE 256
 #define MAX_CMD_ARGS 16

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -1,5 +1,7 @@
 #include "../include/shell.h"
 #include "../include/colors.h"
+#include "../include/integer.h"
+#include "../include/log.h"
 #include "../include/memory.h"
 #include "../include/mm.h"
 #include "../include/string.h"
@@ -20,6 +22,15 @@ void shell_init(void) {
     buffer_pos = 0;
     terminal_writestring(cli_nav);
 }
+
+static int shell_parse(char *cmd, char **args) {
+  int argc = 0;
+  int i = 0;
+
+  cmd = str_trim(cmd);
+  if (cmd == NULL || cmd[0] == '\0') {
+    return 0;
+  };
 
   while (cmd[i] != '\0' && argc < MAX_CMD_ARGS) {
     args[argc++] = &cmd[i];

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -12,6 +12,9 @@ static int buffer_pos = 0;
 static char cli_nav[58] = COLOR_RED_BRIGHT "kernel" COLOR_CYAN_BRIGHT "@" COLOR_WHITE_BRIGHT "auri-os" COLOR_RESET "~" COLOR_GREEN_BRIGHT "$ " COLOR_RESET;
 
 void shell_init(void) {
+    // Flush any keystrokes captured by the keyboard interrupt during boot.
+    memset(buffer, 0, BUFFER_SIZE);
+    buffer_pos = 0;
     terminal_writestring(cli_nav);
 }
 


### PR DESCRIPTION
Closes #67

Fixes boot sequence keystroke leak by clearing the shell buffer during initialization, preventing "ghost" characters from appearing on the prompt.

**Special notes**
- `src/kernel/shell.c`: Added buffer clearing in `shell_init()` to discard keystrokes captured during boot.

**Checklist**
- [x] Backwards compatibility (no behavior change for normal operation)