### PR TITLE
fix: #43 complete MMU driver implementation

### DIFF
--- a/src/cpu/isr.c
+++ b/src/cpu/isr.c
@@ -37,12 +37,16 @@ static const char *exception_messages[32] = {
     "Reserved"
 };
 
+extern void mmu_handle_page_fault(uint32_t error_code);
+
 void isr_handler(registers_t *regs)
 {
     if (regs->int_no < 32) {
         terminal_writestring("EXCEPTION: ");
         terminal_writestring(exception_messages[regs->int_no]);
         terminal_writestring("\n");
+        if (regs->int_no == 14)
+          mmu_handle_page_fault(regs->err_code);
         KPANIC(exception_messages[regs->int_no]);
         for (;;) {
           asm volatile("cli; hlt");

--- a/src/include/integer.h
+++ b/src/include/integer.h
@@ -1,8 +1,11 @@
 #ifndef INTEGER_H
 #define INTEGER_H
 
+#include <stdint.h>
+
 int	atoi(char *str);
 char *itoa(int nb, char *buffer);
+uint32_t htoi(const char *hex_str);
 void putnbr(int nb);
 
 #endif

--- a/src/include/mm.h
+++ b/src/include/mm.h
@@ -2,6 +2,7 @@
 #define MM_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 extern char kernel_end;
 
@@ -11,5 +12,12 @@ extern void pmm_mark_region_used(uint32_t base, uint32_t size);
 extern uint32_t pmm_alloc_frame(void);
 extern uint32_t pmm_free_frame(uint32_t phys_addr);
 extern void pmm_dump_bitmap(uint32_t bytes_to_dump);
+extern void mmu_init();
+extern void mmu_enable();
+extern uint8_t mmu_is_paging_enabled(void);
+extern void mmu_map_page(uint32_t phys_addr, uint32_t virt_addr, bool is_writeable, bool is_user); 
+
+extern void mmu_view_mappings(void);
+extern void mmu_debug_peek(uint32_t addr);
 
 #endif

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -148,6 +148,14 @@ void kernel_main(uint32_t magic, multiboot_info_t *mboot_ptr) {
 
     init_mem(mboot_ptr);
     pmm_dump_bitmap(128);
+    mmu_init();
+    mmu_enable();
+
+    if (mmu_is_paging_enabled() == 1) {
+        KINFO("[MMU] Matrix activated: Paging is physically ON!");
+    } else {
+        KPANIC("[MMU] Paging failed to enable!");
+    }
 
     terminal_writestring("AuriOS Kernel v0.2\n");
     sleep(100);

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -1,221 +1,226 @@
 #include "../include/shell.h"
-#include "../include/terminal.h"
-#include "../include/string.h"
-#include "../include/timer.h"
-#include "../include/integer.h"
 #include "../include/colors.h"
+#include "../include/integer.h"
+#include "../include/log.h"
 #include "../include/mm.h"
+#include "../include/string.h"
+#include "../include/terminal.h"
+#include "../include/timer.h"
 
 #define BUFFER_SIZE 256
 #define MAX_CMD_ARGS 16
 static char buffer[BUFFER_SIZE];
 static int buffer_pos = 0;
-static char cli_nav[58] = COLOR_RED_BRIGHT "kernel" COLOR_CYAN_BRIGHT "@" COLOR_WHITE_BRIGHT "auri-os" COLOR_RESET "~" COLOR_GREEN_BRIGHT "$ " COLOR_RESET;
+static char cli_nav[58] = COLOR_RED_BRIGHT
+    "kernel" COLOR_CYAN_BRIGHT "@" COLOR_WHITE_BRIGHT "auri-os" COLOR_RESET
+    "~" COLOR_GREEN_BRIGHT "$ " COLOR_RESET;
 
-void shell_init(void) {
-    terminal_writestring(cli_nav);
-}
+void shell_init(void) { terminal_writestring(cli_nav); }
 
-static int shell_parse(char* cmd, char** args)
-{
-    int argc = 0;
-    int i = 0;
-    
-    cmd = str_trim(cmd);
-    if (cmd == NULL || cmd[0] == '\0') {
-        return 0;
-    };
+static int shell_parse(char *cmd, char **args) {
+  int argc = 0;
+  int i = 0;
 
-    while (cmd[i] != '\0' && argc < MAX_CMD_ARGS) {
-        args[argc++] = &cmd[i];
+  cmd = str_trim(cmd);
+  if (cmd == NULL || cmd[0] == '\0') {
+    return 0;
+  };
 
-        while (cmd[i] != '\0' && cmd[i] != ' ') {
-            i++;
-        }
+  while (cmd[i] != '\0' && argc < MAX_CMD_ARGS) {
+    args[argc++] = &cmd[i];
 
-        if (cmd[i] == ' ') {
-            cmd[i++] = '\0';
-        }
-
-        while (cmd[i] == ' ') {
-            i++;
-        }
+    while (cmd[i] != '\0' && cmd[i] != ' ') {
+      i++;
     }
 
-    args[argc] = NULL;
-    return argc;
+    if (cmd[i] == ' ') {
+      cmd[i++] = '\0';
+    }
+
+    while (cmd[i] == ' ') {
+      i++;
+    }
+  }
+
+  args[argc] = NULL;
+  return argc;
 }
 
 // Show value with it's unit. if newline = 1, then make a new line
-void print_unit(uint32_t val, const char* unit, int new_line)
-{
-    char out_buf[32];
-    itoa(val, out_buf);
-    terminal_writestring(out_buf);
-    terminal_writestring(unit);
-    if (new_line == 1)
-        terminal_writestring("\n");
+void print_unit(uint32_t val, const char *unit, int new_line) {
+  char out_buf[32];
+  itoa(val, out_buf);
+  terminal_writestring(out_buf);
+  terminal_writestring(unit);
+  if (new_line == 1)
+    terminal_writestring("\n");
 }
 
-static void shell_execute(char* cmd)
-{
-    char* args[MAX_CMD_ARGS];
-    int argc = shell_parse(cmd, args);
-    if (argc == 0) return;
+void debug_trigger_page_fault(void) {
+  terminal_writestring("\n");
+  KINFO("[TEST] Attempting to read unmapped memory at 10 MB...");
 
-    char* cmd_name = args[0];
+  uint32_t *illegal_ptr = (uint32_t *)0x00A00000;
 
-    if (strcmp(cmd_name, "help") == 0) {
-        terminal_writestring("\nhelp - show this command\n");
-        terminal_writestring("about - show informations about AuriOS\n");
-        terminal_writestring("clear - clear the terminal\n");
+  volatile uint32_t crash_value = *illegal_ptr;
+
+  (void)crash_value;
+
+  KPANIC("MMU failed to block unmapped memory access!");
+}
+
+static void shell_execute(char *cmd) {
+  char *args[MAX_CMD_ARGS];
+  int argc = shell_parse(cmd, args);
+  if (argc == 0)
+    return;
+
+  char *cmd_name = args[0];
+
+  if (strcmp(cmd_name, "help") == 0) {
+    terminal_writestring("\nhelp - show this command\n");
+    terminal_writestring("about - show informations about AuriOS\n");
+    terminal_writestring("clear - clear the terminal\n");
+    terminal_writestring("uptime - show uptime since machine started\n");
+    terminal_writestring("echo - repeats your input to the console\n");
+    terminal_writestring("crash - make the machine freeze (fun cmd)\n\n");
+  } else if (strcmp(cmd_name, "clear") == 0) {
+    terminal_clear();
+  } else if (strcmp(cmd_name, "about") == 0) {
+    terminal_writestring("\n        X                 \n");
+    terminal_writestring("       XXX                " COLOR_RED_BRIGHT
+                         "kernel" COLOR_CYAN_BRIGHT "@" COLOR_WHITE_BRIGHT
+                         "auri-os" COLOR_RESET "\n");
+    terminal_writestring("      XXXXX               \n");
+    terminal_writestring("     X XXXXX              Kernel: AuriKernel\n");
+    terminal_writestring("    XXX XXXXX             Version: 0.2\n");
+    terminal_writestring("   XXXXX XXXXX            Release: 2-14-26\n");
+    terminal_writestring("  XXXXXX  XXXXX           \n");
+    terminal_writestring(" XXXXXX    XXXXX          \n");
+    terminal_writestring("XXXXXX      XXXXX         \n\n");
+    terminal_writestring("Type 'help' for available commands\n\n");
+  } else if (strcmp(cmd_name, "crash") == 0) {
+    asm volatile("cli");
+    for (;;)
+      asm volatile("hlt");
+  } else if (strcmp(cmd_name, "uptime") == 0) {
+    uint32_t ticks = get_tick();
+    uint32_t total_seconds = ticks / 1000;
+    uint32_t seconds = total_seconds % 60;
+
+    uint32_t total_minutes = total_seconds / 60;
+    uint32_t minutes = total_minutes % 60;
+
+    uint32_t hours = total_minutes / 60;
+
+    int j = 1;
+    int raw = 0;
+    int sec = 0;
+    int pretty = 0;
+    while (j < argc && args[j][0] == '-') {
+      if (strcmp(args[j], "-h") == 0) {
         terminal_writestring("uptime - show uptime since machine started\n");
-        terminal_writestring("echo - repeats your input to the console\n");
-        terminal_writestring("crash - make the machine freeze (fun cmd)\n\n");
-    }
-    else if (strcmp(cmd_name, "clear") == 0) {
-        terminal_clear();
-    }
-    else if (strcmp(cmd_name, "about") == 0) {
-        terminal_writestring("\n        X                 \n");
-        terminal_writestring("       XXX                " COLOR_RED_BRIGHT "kernel" COLOR_CYAN_BRIGHT "@" COLOR_WHITE_BRIGHT "auri-os" COLOR_RESET"\n");
-        terminal_writestring("      XXXXX               \n");
-        terminal_writestring("     X XXXXX              Kernel: AuriKernel\n");
-        terminal_writestring("    XXX XXXXX             Version: 0.2\n");
-        terminal_writestring("   XXXXX XXXXX            Release: 2-14-26\n");
-        terminal_writestring("  XXXXXX  XXXXX           \n");
-        terminal_writestring(" XXXXXX    XXXXX          \n");
-        terminal_writestring("XXXXXX      XXXXX         \n\n");
-        terminal_writestring("Type 'help' for available commands\n\n");
-    }
-    else if (strcmp(cmd_name, "crash") == 0) {
-        asm volatile("cli");
-        for (;;) asm volatile("hlt");
-    }
-    else if (strcmp(cmd_name, "uptime") == 0) {
-        uint32_t ticks = get_tick();
-        uint32_t total_seconds = ticks / 1000;
-        uint32_t seconds = total_seconds % 60;
-        
-        uint32_t total_minutes = total_seconds / 60;
-        uint32_t minutes = total_minutes % 60;
-        
-        uint32_t hours = total_minutes / 60;
-
-        int j = 1;
-        int raw = 0;
-        int sec = 0;
-        int pretty = 0;
-        while (j < argc && args[j][0] == '-'){
-            if (strcmp(args[j], "-h") == 0) {
-                terminal_writestring("uptime - show uptime since machine started\n");
-                terminal_writestring("-h     - show this message\n");
-                terminal_writestring("-r     - show uptime in miliseconds\n");
-                terminal_writestring("-s     - show uptime in seconds\n");
-                terminal_writestring("-p     - show uptime in a pretty format\n");
-                return;
-            }
-            else if (strcmp(args[j], "-r") == 0)
-                raw = 1;
-            else if (strcmp(args[j], "-s") == 0)
-                sec = 1;
-            else if (strcmp(args[j], "-p") == 0)
-                pretty = 1;
-            else {
-                break;
-            }
-            j++;
-        }
-
-        if (raw == 1){
-            print_unit(ticks, "ms", 1);
-        }
-        else if (sec == 1){
-            print_unit(total_seconds, "s", 1);
-        }
-        else if (pretty == 1) {
-            terminal_writestring("Current Uptime: \n");
-            if (hours != 0)
-                print_unit(hours, hours > 1 ? " hours" : " hour", 1);
-            print_unit(minutes, minutes > 1 ? " minutes" : " minute", 1);
-            print_unit(seconds, seconds > 1 ? " seconds" : " second", 1);
-            terminal_writestring("\n");
-        }
-        else {
-            terminal_writestring("Current Uptime: ");
-            print_unit(hours, "h ", 0);
-            print_unit(minutes, "m ", 0);
-            print_unit(seconds, "s", 1);
-        }
-    }
-    else if (strcmp(cmd_name, "echo") == 0) {
-        int j = 1;
-        int skip_newline = 0;
-
-        while (j < argc && args[j][0] == '-') {
-            if (strcmp(args[j], "-n") == 0){
-                skip_newline = 1;
-            }
-            else if (strcmp(args[j], "-h") == 0){
-                terminal_writestring("echo - repeats your input to the console\n\n");
-                terminal_writestring("-h   - show this command\n");
-                terminal_writestring("-n   - do not output the trailing new line");
-                terminal_writestring("\n");
-                return;
-
-            } else {
-                // No more recognized args
-                break;
-            }
-            j++;
-        }
-
-        while(j < argc){
-            terminal_writestring(args[j]);
-            terminal_writestring(" ");
-            j++;
-        }
-        
-        if (!skip_newline)
-            terminal_writestring("\n");
-    }
-    else if (strcmp(cmd_name, "memdump") == 0) {
-        // for now i print 128 bytes all the time but when args parsings will be set we can just print the size we want
-        pmm_dump_bitmap(128);
-    }
-    else {
-        terminal_writestring("command not found: ");
-        terminal_writestring(cmd_name);
-        terminal_putchar('\n');
+        terminal_writestring("-h     - show this message\n");
+        terminal_writestring("-r     - show uptime in miliseconds\n");
+        terminal_writestring("-s     - show uptime in seconds\n");
+        terminal_writestring("-p     - show uptime in a pretty format\n");
+        return;
+      } else if (strcmp(args[j], "-r") == 0)
+        raw = 1;
+      else if (strcmp(args[j], "-s") == 0)
+        sec = 1;
+      else if (strcmp(args[j], "-p") == 0)
+        pretty = 1;
+      else {
+        break;
+      }
+      j++;
     }
 
+    if (raw == 1) {
+      print_unit(ticks, "ms", 1);
+    } else if (sec == 1) {
+      print_unit(total_seconds, "s", 1);
+    } else if (pretty == 1) {
+      terminal_writestring("Current Uptime: \n");
+      if (hours != 0)
+        print_unit(hours, hours > 1 ? " hours" : " hour", 1);
+      print_unit(minutes, minutes > 1 ? " minutes" : " minute", 1);
+      print_unit(seconds, seconds > 1 ? " seconds" : " second", 1);
+      terminal_writestring("\n");
+    } else {
+      terminal_writestring("Current Uptime: ");
+      print_unit(hours, "h ", 0);
+      print_unit(minutes, "m ", 0);
+      print_unit(seconds, "s", 1);
+    }
+  } else if (strcmp(cmd_name, "echo") == 0) {
+    int j = 1;
+    int skip_newline = 0;
+
+    while (j < argc && args[j][0] == '-') {
+      if (strcmp(args[j], "-n") == 0) {
+        skip_newline = 1;
+      } else if (strcmp(args[j], "-h") == 0) {
+        terminal_writestring("echo - repeats your input to the console\n\n");
+        terminal_writestring("-h   - show this command\n");
+        terminal_writestring("-n   - do not output the trailing new line");
+        terminal_writestring("\n");
+        return;
+
+      } else {
+        // No more recognized args
+        break;
+      }
+      j++;
+    }
+
+    while (j < argc) {
+      terminal_writestring(args[j]);
+      terminal_writestring(" ");
+      j++;
+    }
+
+    if (!skip_newline)
+      terminal_writestring("\n");
+  } else if (strcmp(cmd_name, "memdump") == 0) {
+    pmm_dump_bitmap(atoi(args[1]));
+  } else if (strcmp(cmd_name, "mia") == 0) {
+    debug_trigger_page_fault();
+  } else if (strcmp(cmd_name, "mmap") == 0) {
+    mmu_view_mappings();
+  } else if (strcmp(cmd_name, "peek") == 0) {
+    uint32_t addr = htoi(args[1]);
+    mmu_debug_peek(addr);
+  } else {
+    terminal_writestring("command not found: ");
+    terminal_writestring(cmd_name);
+    terminal_putchar('\n');
+  }
 }
 
-void shell_handle_key(char c)
-{
-    if (c == 0x0C) {
-        terminal_clear();
-		buffer_pos = 0;
-        shell_init();
-        return;
+void shell_handle_key(char c) {
+  if (c == 0x0C) {
+    terminal_clear();
+    buffer_pos = 0;
+    shell_init();
+    return;
+  }
+  if (c == '\n') {
+    terminal_putchar('\n');
+    buffer[buffer_pos] = '\0';
+    shell_execute(buffer);
+    buffer_pos = 0;
+    terminal_writestring(cli_nav);
+  } else if (c == '\b') {
+    if (buffer_pos > 0) {
+      buffer_pos--;
+      terminal_backspace();
     }
-    if (c == '\n') {
-        terminal_putchar('\n');
-        buffer[buffer_pos] = '\0';
-        shell_execute(buffer);
-        buffer_pos = 0;
-        terminal_writestring(cli_nav);
+  } else {
+    if (buffer_pos < BUFFER_SIZE - 1) {
+      buffer[buffer_pos++] = c;
+      terminal_putchar(c);
     }
-    else if (c == '\b') {
-        if (buffer_pos > 0) {
-            buffer_pos--;
-            terminal_backspace();
-        }
-    }
-    else {
-        if (buffer_pos < BUFFER_SIZE - 1) {
-            buffer[buffer_pos++] = c;
-            terminal_putchar(c);
-        }
-    }
+  }
 }

--- a/src/lib/integer.c
+++ b/src/lib/integer.c
@@ -68,3 +68,35 @@ char *itoa(int nb, char *buffer)
     return (buffer);
 }
 
+uint32_t htoi(const char *hex_str) {
+    uint32_t result = 0;
+
+    while (*hex_str == ' ') {
+        hex_str++;
+    }
+
+    if (hex_str[0] == '0' && (hex_str[1] == 'x' || hex_str[1] == 'X')) {
+        hex_str += 2;
+    }
+
+    while (*hex_str != '\0') {
+        char c = *hex_str;
+        uint32_t value = 0;
+
+        if (c >= '0' && c <= '9') {
+            value = c - '0';
+        } else if (c >= 'a' && c <= 'f') {
+            value = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'F') {
+            value = c - 'A' + 10;
+        } else {
+            break;
+        }
+
+        result = (result << 4) | value;
+        
+        hex_str++;
+    }
+
+    return result;
+}

--- a/src/mm/mmu.zig
+++ b/src/mm/mmu.zig
@@ -1,0 +1,224 @@
+const std = @import("std");
+
+extern fn pmm_alloc_frame() usize;
+extern fn serial_write_string(str: [*c]const u8) void;
+extern fn print_hex(val: usize) void;
+
+const PAGE_SIZE = 4096;
+
+const PageTableEntry = packed struct {
+    present: u1 = 0, // page is present in RAM ? present == 0 and we try to read it -> page fault
+    rw: u1 = 0, // 0 = read only, 1 = read & write
+    user: u1 = 0, // 0 = kernel only, 1 = user (Ring 3)
+    write_through: u1 = 0,
+    cache_disable: u1 = 0,
+    accessed: u1 = 0,
+    dirty: u1 = 0,
+    pat: u1 = 0,
+    global: u1 = 0,
+    available: u3 = 0, // Free bits for OS
+    physical_frame: u20 = 0, // 20 high bits of physical address
+};
+
+const PageDirectoryEntry = packed struct {
+    present: u1 = 0,
+    rw: u1 = 0,
+    user: u1 = 0,
+    write_through: u1 = 0,
+    cache_disable: u1 = 0,
+    accessed: u1 = 0,
+    ignored: u1 = 0,
+    page_size: u1 = 0, // 0 = 4 Ko pages, 1 = 4 Mo pages
+    global: u1 = 0,
+    available: u3 = 0,
+    pt_frame: u20 = 0, // Physical address of the page table
+};
+
+const PageTable = [1024]PageTableEntry;
+const PageDirectory = [1024]PageDirectoryEntry;
+
+var kernel_directory: *PageDirectory = undefined;
+
+export fn mmu_init() void {
+    const pd_addr = pmm_alloc_frame();
+    kernel_directory = @as(*PageDirectory, @ptrFromInt(pd_addr));
+
+    @memset(@as([*]u8, @ptrCast(kernel_directory))[0..PAGE_SIZE], 0);
+    const pt_addr = pmm_alloc_frame();
+    const first_table = @as(*PageTable, @ptrFromInt(pt_addr));
+    @memset(@as([*]u8, @ptrCast(first_table))[0..PAGE_SIZE], 0);
+
+    var i: u32 = 0;
+    while (i < 1024) : (i += 1) {
+        first_table[i] = PageTableEntry{
+            .present = 1,
+            .rw = 1, // kernel can write
+            .user = 0, // libOS and User cannot access to this area
+            .physical_frame = @as(u20, @truncate(i)),
+        };
+    }
+
+    kernel_directory[0] = PageDirectoryEntry{
+        .present = 1,
+        .rw = 1,
+        .user = 0,
+        .pt_frame = @as(u20, @truncate(pt_addr / PAGE_SIZE)),
+    };
+}
+
+export fn mmu_enable() void {
+    const ptr_phys_addr = @intFromPtr(kernel_directory);
+
+    asm volatile (
+        \\ mov %[addr], %%cr3
+        \\ mov %%cr0, %%eax
+        \\ or $0x80000000, %%eax
+        \\ mov %%eax, %%cr0
+        :
+        : [addr] "r" (ptr_phys_addr),
+        : .{ .eax = true });
+}
+
+export fn mmu_is_paging_enabled() u8 {
+    var cr0: u32 = undefined;
+
+    asm volatile ("mov %%cr0, %[val]"
+        : [val] "=r" (cr0),
+    );
+
+    if ((cr0 & 0x80000000) != 0) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+export fn mmu_map_page(phys_addr: usize, virt_addr: usize, is_writeable: bool, is_user: bool) void {
+    // virtual address is splitted like
+    // [10 bits Directory][10 bits Table][12 bits Offset]
+    const pd_index = virt_addr >> 22;
+    const pt_index = (virt_addr >> 12) & 0x3FF;
+
+    const pde = &kernel_directory[pd_index];
+    var table_ptr: *PageTable = undefined;
+
+    if (pde.present == 0) {
+        // page does not already exist for this 4Mo Area
+        // so we ask PMM for a new one
+        const new_pt_phys = pmm_alloc_frame();
+        table_ptr = @as(*PageTable, @ptrFromInt(new_pt_phys));
+
+        // clean the new table
+        @memset(@as([*]u8, @ptrCast(table_ptr))[0..PAGE_SIZE], 0);
+
+        // register it in Directory
+        pde.* = PageDirectoryEntry{
+            .present = 1,
+            .rw = if (is_writeable) 1 else 0,
+            .user = if (is_user) 1 else 0,
+            .pt_frame = @as(u20, @truncate(new_pt_phys / PAGE_SIZE)),
+        };
+    } else {
+        // already exist so we just grab it address
+        const pt_phys = @as(usize, pde.pt_frame) * PAGE_SIZE;
+        table_ptr = @as(*PageTable, @ptrFromInt(pt_phys));
+    }
+
+    table_ptr[pt_index] = PageTableEntry{
+        .present = 1,
+        .rw = if (is_writeable) 1 else 0,
+        .user = if (is_user) 1 else 0,
+        .physical_frame = @as(u20, @truncate(phys_addr / PAGE_SIZE)),
+    };
+
+    asm volatile ("invlpg (%[addr])"
+        :
+        : [addr] "r" (virt_addr),
+        : .{ .memory = true });
+}
+
+// ================
+// DEBUG
+// ===============
+
+export fn mmu_get_fault_address() usize {
+    var addr: usize = undefined;
+    asm volatile ("mov %%cr2, %[val]"
+        : [val] "=r" (addr),
+    );
+    return addr;
+}
+
+export fn mmu_view_mappings() void {
+    serial_write_string("\r\n=== ACTIVE MEMORY MAPPINGS ===\r\n");
+
+    var i: usize = 0;
+    while (i < 1024) : (i += 1) {
+        const pde = kernel_directory[i];
+        if (pde.present == 1) {
+            const start_addr = i * 4 * 1024 * 1024;
+            const end_addr = start_addr + (4 * 1024 * 1024) - 1;
+
+            serial_write_string("Range: ");
+            print_hex(start_addr);
+            serial_write_string(" - ");
+            print_hex(end_addr);
+
+            if (pde.user == 1) {
+                serial_write_string(" [USER] ");
+            } else {
+                serial_write_string(" [KERNEL] ");
+            }
+
+            if (pde.rw == 1) {
+                serial_write_string("R/W\r\n");
+            } else {
+                serial_write_string("R-O\r\n");
+            }
+        }
+    }
+    serial_write_string("===============================\r\n");
+}
+
+export fn mmu_debug_peek(addr: usize) void {
+    serial_write_string("\r\n[DEBUG] Peeking at ");
+    print_hex(addr);
+    serial_write_string("...\r\n");
+
+    const ptr = @as(*volatile u8, @ptrFromInt(addr));
+    const value = ptr.*;
+
+    serial_write_string("Value found: ");
+    print_hex(value);
+    serial_write_string("\r\n");
+}
+
+export fn mmu_handle_page_fault(error_code: u32) noreturn {
+    var cr2: usize = undefined;
+
+    asm volatile ("mov %%cr2, %[val]"
+        : [val] "=r" (cr2),
+    );
+
+    serial_write_string("\r\n\x1b[91m[PANIC] PAGE FAULT DETECTED!\x1b[0m\r\n");
+    serial_write_string("Faulting Address : ");
+    print_hex(cr2);
+    serial_write_string("\r\n");
+
+    serial_write_string("Reason           : ");
+    if ((error_code & 1) == 0) {
+        serial_write_string("Page not present (Unmapped memory)");
+    } else {
+        serial_write_string("Protection violation (Access denied)");
+    }
+
+    if ((error_code & 2) != 0) {
+        serial_write_string(" on WRITE attempt\r\n");
+    } else {
+        serial_write_string(" on READ attempt\r\n");
+    }
+
+    while (true) {
+        asm volatile ("cli; hlt");
+    }
+}

--- a/src/mm/pmm.zig
+++ b/src/mm/pmm.zig
@@ -17,7 +17,7 @@ pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_
     }
 }
 
-fn print_hex(val: usize) void {
+export fn print_hex(val: usize) void {
     serial_write_string("0x");
     var temp = val;
     var buf: [8]u8 = undefined;


### PR DESCRIPTION
In this PR, I've written a complete implementation of a `MMU (Memory Management Unit)` driver.
This allows for strict memory partitioning.

Now, once the `MMU` has been initialized and activated, it will no longer be possible to access any part of the RAM.
It will ensure that you have the proper permissions to read or write.

Expect to encounter page faults if you manipulate pointers too aggressively.
This addition is therefore a major step forward for security.


In a second step, I added debugging commands:

`peek <address>`:

> Allows reading the contents of a specific memory address during runtime

##### Valid address:
<img width="319" height="50" alt="image" src="https://github.com/user-attachments/assets/6e814800-fcc4-4b19-997d-4d601ec7fabf" />

##### Invalid address:
<img width="599" height="91" alt="image" src="https://github.com/user-attachments/assets/2713a1dd-78f0-4a01-b418-ab991ca6b5c5" />


`mmap`:

> Displays on the COM port the memory areas currently known to the MMU and provides information about them, such as permissions and who owns the area (kernel/user)
<img width="770" height="116" alt="image" src="https://github.com/user-attachments/assets/88f3777e-ef51-409a-8a73-2a4f18020e3e" />

`mia`:

> Forces a page fault by attempting to access a memory area that has not been communicated to the MMU