### PR TITLE
feat: Page fault handling + terminal_writehex function

### DIFF
--- a/src/cpu/isr.c
+++ b/src/cpu/isr.c
@@ -1,6 +1,8 @@
 #include "../include/isr.h"
 #include "../include/terminal.h"
 #include "../include/log.h"
+#include <stdbool.h>
+
 
 static const char *exception_messages[32] = {
     "Division By Zero",
@@ -37,12 +39,37 @@ static const char *exception_messages[32] = {
     "Reserved"
 };
 
+// Helper function to read CR2 register
+static inline uintptr_t read_cr2(void)
+{
+    uintptr_t cr2;
+    __asm__ __volatile__("mov %%cr2, %0" : "=r" (cr2));
+    return cr2;
+}
+
 void isr_handler(registers_t *regs)
 {
+    if (regs->int_no == 14){
+        uintptr_t faulting_address = read_cr2();
+        
+        bool present_violation = (regs->err_code & 0x1);
+        bool write_violation   = (regs->err_code & 0x2);
+        bool user_mode         = (regs->err_code & 0x4);
+
+        terminal_writestring("[PANIC] Page fault at ");
+        terminal_writehex(faulting_address);
+        terminal_writestring("\nReason:");
+        terminal_writestring(present_violation ? "Protection-Violation " : "Page-Not-Present ");
+        terminal_writestring(write_violation ? "Write-Access " : "Read-Access ");
+        terminal_writestring(user_mode ? "User-Mode" : "Supervisor-Mode");
+        
+        terminal_writestring("\n");
+    }
     if (regs->int_no < 32) {
         terminal_writestring("EXCEPTION: ");
         terminal_writestring(exception_messages[regs->int_no]);
         terminal_writestring("\n");
+        
         KPANIC(exception_messages[regs->int_no]);
         for (;;) {
           asm volatile("cli; hlt");

--- a/src/include/terminal.h
+++ b/src/include/terminal.h
@@ -36,5 +36,6 @@ void terminal_clear_after_cursor(void);
 void terminal_set_cursor(size_t x, size_t y);
 void terminal_enable_cursor(uint8_t cursor_start, uint8_t cursor_end);
 void terminal_update_cursor(size_t x, size_t y);
+void terminal_writehex(size_t val);
 
 #endif

--- a/src/kernel/terminal.c
+++ b/src/kernel/terminal.c
@@ -162,3 +162,22 @@ void terminal_backspace(void) {
 void terminal_writestring(const char* data) {
 	terminal_write(data, strlen(data));
 }
+// Based on src/mm/pmm.zig > fn print_hex
+void terminal_writehex(size_t val){
+    terminal_writestring("0x");
+
+    const int num_chars = sizeof(size_t) * 2;
+
+    char buf[num_chars];
+    size_t temp = val;
+
+    for (int i = num_chars - 1; i >= 0; i--) {
+        uint8_t nibble = temp & 0xF;
+        buf[i] = (nibble < 10) ? ('0' + nibble) : ('A' + (nibble - 10));
+        temp >>= 4;
+    }
+
+    for (int j = 0; j < num_chars; j++) {
+        terminal_writestring(&buf[j]);
+    }
+}


### PR DESCRIPTION
fix #44

Handle page fault exceptions & create a `terminal_writehex` function to send hexadecimal in terminal.
Page Fault Exception can't be tested now, pagination is not enabled if I understand correctly.

- **feat: terminal_writehex function**
- **feat: page fault handling**
