### PR TITLE
fix-mem: fix error in pmm_free_frame()

### DIFF
--- a/src/mm/pmm.zig
+++ b/src/mm/pmm.zig
@@ -141,5 +141,5 @@ export fn pmm_alloc_frame() usize {
 }
 
 export fn pmm_free_frame(phys_addr: usize) void {
-    pmm_mark_region_used(phys_addr, PAGE_SIZE);
+    pmm_mark_region_free(phys_addr, PAGE_SIZE);
 }


### PR DESCRIPTION
fix critical error in `pmm_free_frame()` (my bad), i called `pmm_mark_region_used()` instead of `pmm_mark_region_used()` .
So the memory could never be freed, and worse, when we tried to free it, we allocated more memory, which would have caused a crash.