### PR TITLE
gdt: add tss for context switching

### DIFF
--- a/src/cpu/gdt.c
+++ b/src/cpu/gdt.c
@@ -1,10 +1,12 @@
 #include "../include/gdt.h"
 #include "../include/log.h"
+#include "../include/memory.h"
 
-#define GDT_ENTRY_COUNT 5
+#define GDT_ENTRY_COUNT 6
 
 uint64_t gdt[GDT_ENTRY_COUNT];
 struct gdt_ptr gp;
+struct tss_entry tss;
 
 extern void gdt_flush(uint32_t);
 
@@ -23,11 +25,20 @@ uint64_t create_descriptor(uint32_t base, uint32_t limit, uint16_t flag)
 
 void gdt_init()
 {
+    memset(&tss, 0, sizeof(struct tss_entry));
+
+    tss.ss0 = 0x10;
+    tss.esp0 = 0x90000;
+
     gdt[0] = create_descriptor(0, 0, 0);                    // null
     gdt[1] = create_descriptor(0, 0x000FFFFF, GDT_CODE_PL0); // code pl0
     gdt[2] = create_descriptor(0, 0x000FFFFF, GDT_DATA_PL0); // data pl0
     gdt[3] = create_descriptor(0, 0x000FFFFF, GDT_CODE_PL3); // code pl3
     gdt[4] = create_descriptor(0, 0x000FFFFF, GDT_DATA_PL3); // data pl3
+  
+    uint32_t tss_base = (uint32_t)&tss;
+    uint32_t tss_limit = sizeof(struct tss_entry) - 1;
+    gdt[5] = create_descriptor(tss_base, tss_limit, 0x89);
 
     gp.limit = sizeof(gdt) - 1;
     gp.base = (uint32_t)&gdt;

--- a/src/cpu/gdt_flush.asm
+++ b/src/cpu/gdt_flush.asm
@@ -13,4 +13,6 @@ gdt_flush:
 
         jmp 0x08:.flush         ; far jump to reload CS
     .flush:
+        mov ax, 0x2B
+        ltr ax
         ret

--- a/src/include/gdt.h
+++ b/src/include/gdt.h
@@ -37,6 +37,24 @@ struct __attribute__((packed)) gdt_ptr {
     uint32_t base;
 };
 
+
+struct tss_entry {
+    uint32_t prev_tss;
+    uint32_t esp0;
+    uint32_t ss0;
+    uint32_t esp1;
+    uint32_t ss1;
+    uint32_t esp2;
+    uint32_t ss2;
+    uint32_t cr3;
+    uint32_t eip, eflags, eax, ecx, edx, ebx, esp, ebp, esi, edi;
+    uint32_t es, cs, ss, ds, fs, gs;
+    uint32_t ldt;
+    uint16_t trap;
+    uint16_t iomap_base;
+} __attribute__((packed));
+
+
 uint64_t create_descriptor(uint32_t base, uint32_t limit, uint16_t flag);
 void gdt_init(void);
 


### PR DESCRIPTION
added a TSS (Task State Segment) entry in the GDT to avoid triple fault during contexte switch.
I'm making this PR as a first step towards libOS and the system capabilities