### PR TITLE
Full COM port mirroring for integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ OBJS = $(S_OBJS) $(ASM_OBJS) $(C_OBJS) $(ZIG_OBJS)
 .DEFAULT_GOAL := help
 
 # Phony targets
-.PHONY: all clean help iso run run32 run-mac install-fedora install-arch install-debian
+.PHONY: all clean help iso iso-debug run run32 run-mac install-fedora install-arch install-debian
 
 help:
 	@echo "======================= AuriOS Makefile ======================="
@@ -55,6 +55,7 @@ help:
 	@echo "Available targets:"
 	@echo "  make all            - Build everything"
 	@echo "  make iso            - Build OS binary and create bootable ISO"
+	@echo "  make iso-debug      - Build bootable ISO with Test Mode enabled (serial output)"
 	@echo "  make run            - Build and run in QEMU (x86_64)"
 	@echo "  make run32          - Build and run in QEMU (i386)"
 	@echo "  make run-mac        - Build and run on macOS (direct boot)"
@@ -128,6 +129,12 @@ iso: $(KERNEL_BIN)
 	@echo '}' >> $(ISO_DIR)/boot/grub/grub.cfg
 	@grub-mkrescue -o $(ISO) $(ISO_DIR) 2>/dev/null || grub2-mkrescue -o $(ISO) $(ISO_DIR)
 	@echo "ISO created: $(ISO)"
+
+iso-debug:
+	@echo "Building Test ISO with AURI_TEST_MODE..."
+	@$(MAKE) clean
+	@$(MAKE) CFLAGS="$(CFLAGS) -DAURI_TEST_MODE" iso
+	@echo "Test ISO build complete!"
 
 # Run in QEMU (x86_64)
 run: iso

--- a/src/drivers/serial.c
+++ b/src/drivers/serial.c
@@ -1,7 +1,22 @@
 #include "../include/serial.h"
 #include "../include/io.h"
+#include "../include/isr.h"
+#include "../include/pic.h"
+#include "../include/shell.h"
 
 #define SERIAL_PORT 0x3F8
+
+#ifdef AURI_TEST_MODE
+static void serial_callback(registers_t *regs) {
+    (void)regs;
+    
+    if (inb(SERIAL_PORT + 5) & 1) {
+        char c = inb(SERIAL_PORT);
+        
+        shell_handle_key(c);
+    }
+}
+#endif
 
 void serial_init(void) {
   outb(SERIAL_PORT + 1, 0x00);
@@ -11,6 +26,13 @@ void serial_init(void) {
   outb(SERIAL_PORT + 3, 0x03);
   outb(SERIAL_PORT + 2, 0xC7);
   outb(SERIAL_PORT + 4, 0x0B);
+
+  #ifdef AURI_TEST_MODE
+    outb(SERIAL_PORT + 1, 0x01);
+    
+    irq_register_handler(4, serial_callback);
+    pic_unmask_irq(4);
+#endif
 }
 
 static int serial_is_transmit_empty(void) {
@@ -28,3 +50,4 @@ void serial_write_string(const char *str) {
     serial_write_char(str[i]);
   }
 }
+

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -144,6 +144,10 @@ void kernel_main(uint32_t magic, multiboot_info_t *mboot_ptr) {
     terminal_initialize();
     timer_init(1000);
 
+    #ifdef AURI_TEST_MODE
+      pic_unmask_irq(4);
+    #endif
+
     asm volatile("sti");
 
     init_mem(mboot_ptr);

--- a/src/kernel/terminal.c
+++ b/src/kernel/terminal.c
@@ -2,6 +2,9 @@
 #include "../include/string.h"
 #include "../include/ansi.h"
 #include "../include/io.h"
+#ifdef AURI_TEST_MODE
+      #include "../include/serial.h"
+#endif
 #include <stddef.h>
 #include <stdint.h>
 
@@ -85,7 +88,6 @@ static void terminal_scroll(void) {
 void terminal_putchar(char c) {
   ansi_process_char((uint8_t)c);
   #ifdef AURI_TEST_MODE
-    #include "../include/serial.h"
     serial_write_char(c);
   #endif
 }

--- a/src/kernel/terminal.c
+++ b/src/kernel/terminal.c
@@ -84,6 +84,10 @@ static void terminal_scroll(void) {
 
 void terminal_putchar(char c) {
   ansi_process_char((uint8_t)c);
+  #ifdef AURI_TEST_MODE
+    #include "../include/serial.h"
+    serial_write_char(c);
+  #endif
 }
 
 void terminal_putchar_raw(char c) {

--- a/walkman.yaml
+++ b/walkman.yaml
@@ -1,0 +1,26 @@
+name: "AuriOS Basic Integration Test"
+command: "qemu-system-i386 -cdrom output/AuriOS.iso -m 512M -display none -serial stdio"
+timeout_ms: 10000
+
+boot_sequence:
+  - "[KRN] Starting AuriOS boot sequence..."
+  - "[GDT] Initialized succesfully"
+  - "[PMM] Physical Memory Manager initialized by Zig."
+  - "[MMU] Matrix activated: Paging is physically ON!"
+  - "System ready."
+
+shell_interactions:
+  prompt: "auri-os" 
+  
+  tests:
+    - command: "uptime"
+      expect: "Current Uptime:"
+
+    - command: "echo Bonjour Walkman"
+      expect: "Bonjour Walkman"
+
+    - command: "about"
+      expect: "Version: 0.2"
+
+    - command: "uptime -p"
+      expect: "second"


### PR DESCRIPTION
I am currently working on [Walkman](https://github.com/Auri-OS/Walkman), which will allow for integration testing in CI. For this, I had to implement a compilation flag `AURI_TEST_MODE` to perform mirroring of `VGA -> COM` and `Keyboard -> COM`.

<img width="1846" height="508" alt="image" src="https://github.com/user-attachments/assets/0ecd2507-12d4-45d0-b94e-716346df28d8" />

