### PR TITLE
tests/ci: add integration tests for AuriOS with walkman and integrate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,35 @@ jobs:
           name: AuriOS-Zig-ISO
           path: output/AuriOS.iso
           retention-days: 5
+
+  integration-tests:
+    name: Integration Tests (Walkman)
+    runs-on: ubuntu-latest
+    needs: build-zig
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: install system deps & QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nasm xorriso mtools grub-pc-bin grub-common qemu-system-x86
+
+      - name: install zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Build Test ISO (AURI_TEST_MODE)
+        run: |
+          make clean
+          make USE_ZIG=1 iso-debug
+
+      - name: Install Walkman
+        run: |
+          cargo install --git https://github.com/Auri-OS/walkman.git --tag v0.1.0
+
+      - name: Run Walkman Test Suite
+        run: |
+          walkman tests/integrations --nui

--- a/tests/integrations/memory_tools.yml
+++ b/tests/integrations/memory_tools.yml
@@ -1,0 +1,21 @@
+name: "Memory Diagnostics (PMM/MMU)"
+command: "qemu-system-i386 -cdrom output/AuriOS.iso -m 512M -display none -serial stdio"
+timeout_ms: 8000
+
+boot_sequence:
+  - "System ready."
+
+shell_interactions:
+  prompt: "auri-os"
+  tests:
+    - command: "mmap"
+      expect: "=== ACTIVE MEMORY MAPPINGS ==="
+
+    - command: "memdump 16"
+      expect: "=== PMM BITMAP DUMP ==="
+
+    - command: "memdump"
+      expect: "usage: memdump <size>"
+
+    - command: "peek 0x100000"
+      expect: "Peeking at 0x" 

--- a/tests/integrations/shell.yml
+++ b/tests/integrations/shell.yml
@@ -1,0 +1,21 @@
+name: "Shell Parsing & Robustness"
+command: "qemu-system-i386 -cdrom output/AuriOS.iso -m 512M -display none -serial stdio"
+timeout_ms: 10000
+
+boot_sequence:
+  - "System ready."
+
+shell_interactions:
+  prompt: "auri-os"
+  tests:
+    - command: ""
+      expect: "\n" 
+
+    - command: "jhdsbfjdsbf"
+      expect: "command not found: jhdsbfjdsbf"
+
+    - command: "   echo    AuriOS   Rocks   "
+      expect: "AuriOS Rocks"
+
+    - command: "echo -n test"
+      expect: "test"

--- a/tests/integrations/timer_flags.yml
+++ b/tests/integrations/timer_flags.yml
@@ -1,0 +1,21 @@
+name: "Timer & Uptime Arguments"
+command: "qemu-system-i386 -cdrom output/AuriOS.iso -m 512M -display none -serial stdio"
+timeout_ms: 10000
+
+boot_sequence:
+  - "System ready."
+
+shell_interactions:
+  prompt: "auri-os"
+  tests:
+    - command: "uptime -h"
+      expect: "-r     - show uptime in miliseconds"
+
+    - command: "uptime -r"
+      expect: "ms"
+
+    - command: "uptime -s"
+      expect: "s"
+
+    - command: "uptime -p"
+      expect: "Current Uptime:"

--- a/tests/integrations/walkman.yaml
+++ b/tests/integrations/walkman.yaml
@@ -1,0 +1,26 @@
+name: "AuriOS Basic Integration Test"
+command: "qemu-system-i386 -cdrom output/AuriOS.iso -m 512M -display none -serial stdio"
+timeout_ms: 10000
+
+boot_sequence:
+  - "[KRN] Starting AuriOS boot sequence..."
+  - "[GDT] Initialized succesfully"
+  - "[PMM] Physical Memory Manager initialized by Zig."
+  - "[MMU] Matrix activated: Paging is physically ON!"
+  - "System ready."
+
+shell_interactions:
+  prompt: "auri-os" 
+  
+  tests:
+    - command: "uptime"
+      expect: "Current Uptime:"
+
+    - command: "echo Bonjour Walkman"
+      expect: "Bonjour Walkman"
+
+    - command: "about"
+      expect: "Version: 0.2"
+
+    - command: "uptime -p"
+      expect: "second"


### PR DESCRIPTION
I added our [Walkman ](https://github.com/Auri-OS/Walkman) testing framework to our CI and wrote integration tests in `tests/integrations`.

> [!WARNING]
> This PR is blocked by #81 
> To update this branch, use the command:
> ```bash
> git rebase --rebase-merges develop
> ```