### PR TITLE
ref: replace hardcoded ANSI/VT100 color escapes with shared constants…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Output directory for final binaries
 OUTPUT_DIR = output
 BUILD_DIR = build
+HEADER_DIR = src/include
 ISO_DIR = iso
 
 # Final binaries
@@ -18,12 +19,12 @@ USE_ZIG ?= 0
 ifeq ($(USE_ZIG), 1)
     CC = zig cc -target x86-freestanding-none
     LD = zig ld.lld
-    CFLAGS = -ffreestanding -Wall -Wextra -m32 -Isrc/include -fno-pie -fno-stack-protector -mgeneral-regs-only -fno-sanitize=all
+    CFLAGS = -ffreestanding -Wall -Wextra -m32 -I src/include -fno-pie -fno-stack-protector -mgeneral-regs-only -fno-sanitize=all 
     LDFLAGS = -T linker.ld -nostdlib -z max-page-size=0x1000 --build-id=none
 else
     CC = i686-elf-gcc
     LD = i686-elf-ld
-    CFLAGS = -ffreestanding -O2 -Wall -Wextra -m32 -Isrc/include
+    CFLAGS = -ffreestanding -O2 -Wall -Wextra -m32 -I src/include
     LDFLAGS = -T linker.ld -nostdlib
 endif
 
@@ -34,12 +35,12 @@ C_SOURCES = $(wildcard src/kernel/*.c) $(wildcard src/cpu/*.c) $(wildcard src/li
 S_SOURCES = $(wildcard src/boot/*.s)
 ASM_SOURCES = $(wildcard src/cpu/*.asm)
 ZIG_SOURCES = $(wildcard src/kernel/*.zig) $(wildcard src/mm/*.zig)
-ZIG_OBJS = $(patsubst src/%.zig, $(BUILD_DIR)/%.o, $(ZIG_SOURCES))
 
 # Object files (in build directory)
 C_OBJS = $(patsubst src/%.c, $(BUILD_DIR)/%.o, $(C_SOURCES))
 S_OBJS = $(patsubst src/%.s, $(BUILD_DIR)/%.o, $(S_SOURCES))
 ASM_OBJS = $(patsubst src/%.asm, $(BUILD_DIR)/%.o, $(ASM_SOURCES))
+ZIG_OBJS = $(patsubst src/%.zig, $(BUILD_DIR)/%.o, $(ZIG_SOURCES))
 
 OBJS = $(S_OBJS) $(ASM_OBJS) $(C_OBJS) $(ZIG_OBJS)
 
@@ -68,7 +69,7 @@ help:
 	@echo ""
 	@echo "Zig Toolchain (Optional):"
 	@echo "  make install-zig    - Auto-install Zig compiler based on your OS"
-	@echo "  -USE_ZIG=1          - Compile with Zig toolchain"
+	@echo "  make run* USE_ZIG=1 - Compile with Zig toolchain"
 	@echo "==============================================================="
 
 # Create necessary directories
@@ -97,10 +98,11 @@ $(BUILD_DIR)/%.o: src/%.asm | $(BUILD_DIR)
 	@echo "AS $<"
 	@$(AS) -f elf32 $< -o $@
 
-$(BUILD_DIR)/%.o: src/%.zig | $(BUILD_DIR)
+# Compile zig files (.zig)
+$(BUILD_DIR)/%.o: src/%.zig | $(BUILD_DIR) 
 	@mkdir -p $(dir $@)
 	@echo "ZIG $<"
-	@zig build-obj $< -femit-bin=$@ -target x86-freestanding-none -O ReleaseSafe -fno-stack-check -mcpu=i386
+	@zig build-obj $< -femit-bin=$@ -target x86-freestanding-none -O ReleaseSafe -fno-stack-check -mcpu=i386 -I $(HEADER_DIR)
 
 # Link kernel binary
 $(KERNEL_BIN): $(OBJS) | $(OUTPUT_DIR)

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 # 🌟 AuriOS
 
 ```
-        X       
-       XXX      
-      XXXXX     
-     X XXXXX    
-    XXX XXXXX   
-   XXXXX XXXXX   
-  XXXXXX  XXXXX  
- XXXXXX    XXXXX 
+        X
+       XXX
+      XXXXX
+     X XXXXX
+    XXX XXXXX
+   XXXXX XXXXX
+  XXXXXX  XXXXX
+ XXXXXX    XXXXX
 XXXXXX      XXXXX
 ```
 
@@ -61,16 +61,22 @@ This project demonstrates low-level system programming concepts and serves as a 
   - ISO generation for bootable media
 
 ## ❤️ Contributors
+
 Thank to all the contributors, you are the flame burning in our heart ❤️
+
 <div align="left">
 
-| Profile | GitHub | Role |
-|:-------:|:------:|:----:|
-| <img src="https://github.com/im-nymii.png" width="80" height="80" alt="im-nymii" /> | [nymii](https://github.com/im-nymii) | Founder & Maintainer |
-| <img src="https://github.com/llmaddie.png" width="80" height="80" alt="llmaddie 2" /> | [Maddie](https://github.com/llmaddie) | Co-Founder & Maintainer |
-| <img src="https://github.com/pepedinho.png" width="80" height="80" alt="pepedinho" /> | [pepedinho](https://github.com/pepedinho) | Co-Maintainer |
-| <img src="https://github.com/swtchcoder.png" width="80" height="80" alt="switchcodeur" /> | [switchcodeur](https://github.com/swtchcoder) | Contributor |
-| <img src="https://github.com/proxzr.png" width="80" height="80" alt="proxzr" /> | [proxzr](https://github.com/proxzr) | Contributor |
+|                                           Profile                                           |                     GitHub                      |          Role           |
+| :-----------------------------------------------------------------------------------------: | :---------------------------------------------: | :---------------------: |
+|     <img src="https://github.com/im-nymii.png" width="80" height="80" alt="im-nymii" />     |      [nymii](https://github.com/im-nymii)       |  Founder & Maintainer   |
+|    <img src="https://github.com/llmaddie.png" width="80" height="80" alt="llmaddie 2" />    |      [Maddie](https://github.com/llmaddie)      | Co-Founder & Maintainer |
+|    <img src="https://github.com/pepedinho.png" width="80" height="80" alt="pepedinho" />    |    [pepedinho](https://github.com/pepedinho)    |      Co-Maintainer      |
+|  <img src="https://github.com/swtchcoder.png" width="80" height="80" alt="switchcodeur" />  |  [switchcodeur](https://github.com/swtchcoder)  |       Contributor       |
+|       <img src="https://github.com/proxzr.png" width="80" height="80" alt="proxzr" />       |       [proxzr](https://github.com/proxzr)       |       Contributor       |
+|      <img src="https://github.com/aomitsu.png" width="80" height="80" alt="Aomitsu" />      |      [Aomitsu](https://github.com/aomitsu)      |       Contributor       |
+|       <img src="https://github.com/ivy-js.png" width="80" height="80" alt="ivy-js" />       |       [Ivy-js](https://github.com/ivy-js)       |       Contributor       |
+| <img src="https://github.com/gittihub-jpg.png" width="80" height="80" alt="gittihub-jpg" /> | [gittihub-jpg](https://github.com/gittihub-jpg) |       Contributor       |
+| <img src="https://github.com/jesuiskoriel.png" width="80" height="80" alt="jesuiskoriel" /> | [Jesuiskoriel](https://github.com/Jesuiskoriel) |       Contributor       |
 
 </div>
 
@@ -90,21 +96,25 @@ Before building AuriOS, ensure you have the following tools installed:
 ### Quick Install Dependencies
 
 #### Fedora / RHEL
+
 ```bash
 make install-fedora
 ```
 
 #### Arch Linux
+
 ```bash
 make install-arch
 ```
 
 #### Debian / Ubuntu
+
 ```bash
 make install-debian
 ```
 
 #### macOS
+
 ```bash
 brew install i686-elf-gcc nasm qemu xorriso
 ```
@@ -127,6 +137,7 @@ make all
 ```
 
 This will:
+
 - Compile all C source files
 - Assemble all assembly files
 - Link everything into a kernel binary
@@ -210,6 +221,7 @@ Please read [CONTRIBUTING.md](docs/CONTRIBUTING.md) for details on our code of c
 ## 🗺️ Roadmap
 
 ### Current Version (v0.2.0)
+
 - ✅ Basic kernel initialization
 - ✅ GDT and IDT setup
 - ✅ Keyboard driver
@@ -218,6 +230,7 @@ Please read [CONTRIBUTING.md](docs/CONTRIBUTING.md) for details on our code of c
 - ✅ Memory management basics
 
 ### Planned Features
+
 - [ ] Virtual memory management
 - [ ] File system support (FAT32)
 - [ ] Multi-tasking and process scheduling

--- a/src/include/ansi.h
+++ b/src/include/ansi.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define ANSI_CSI "\x1b["
+
 void ansi_process_char(uint8_t c);
 
 #endif

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -12,10 +12,12 @@
 #include "../include/log.h" 
 #include "../include/multiboot.h"
 #include "../include/mm.h"
+#include "../include/ansi.h"
+#include "../include/colors.h"
 
 static void set_cursor_ansi(int x, int y) {
     char buf[16];
-    terminal_writestring("\x1b[");
+    terminal_writestring(ANSI_CSI);
     itoa(y, buf);
     terminal_writestring(buf);
     terminal_writestring(";");
@@ -39,7 +41,7 @@ void animate_logo(void) {
     };
 
     terminal_clear();
-    terminal_writestring("\x1b[96m");
+    terminal_writestring(COLOR_CYAN_BRIGHT);
 
     int start_y = 6;
     int max_width = 48; 
@@ -72,7 +74,7 @@ void animate_logo(void) {
     int text_x = 28;
     int text_y = 17;
 
-    terminal_writestring("\x1b[97;44m");
+    terminal_writestring(COLOR_WHITE_BRIGHT BG_COLOR_BLUE);
 
     for (int frame = 0; frame < 30; frame++) {
         set_cursor_ansi(text_x, text_y);
@@ -92,7 +94,7 @@ void animate_logo(void) {
     set_cursor_ansi(text_x, text_y);
     terminal_writestring(target_text);
 
-    terminal_writestring("\x1b[0m");
+    terminal_writestring(COLOR_RESET);
     set_cursor_ansi(1, 20);
     sleep(1000);
 }

--- a/src/mm/mmu.zig
+++ b/src/mm/mmu.zig
@@ -1,4 +1,7 @@
 const std = @import("std");
+pub const c = @cImport({
+    @cInclude("../include/colors.h");
+});
 
 extern fn pmm_alloc_frame() usize;
 extern fn serial_write_string(str: [*c]const u8) void;
@@ -200,8 +203,12 @@ export fn mmu_handle_page_fault(error_code: u32) noreturn {
         : [val] "=r" (cr2),
     );
 
-    serial_write_string("\r\n\x1b[91m[PANIC] PAGE FAULT DETECTED!\x1b[0m\r\n");
-    serial_write_string("Faulting Address : ");
+	serial_write_string("\r\n");
+	serial_write_string(c.COLOR_RED_BRIGHT);
+    serial_write_string("[PANIC] PAGE FAULT DETECTED!");
+	serial_write_string("\r\n");
+    serial_write_string(c.COLOR_RESET);
+	serial_write_string("Faulting Address : ");
     print_hex(cr2);
     serial_write_string("\r\n");
 


### PR DESCRIPTION
## Summary
Refactor ANSI/VT100 usage to remove hardcoded color escape sequences and use shared constants.

## Changes
- Replaced hardcoded color escapes in `src/kernel/kernel.c` with constants from `src/include/colors.h`:
  - `\x1b[96m` -> `COLOR_CYAN_BRIGHT`
  - `\x1b[97;44m` -> `COLOR_WHITE_BRIGHT BG_COLOR_BLUE`
  - `\x1b[0m` -> `COLOR_RESET`
- Added `ANSI_CSI` constant in `src/include/ansi.h`.
- Replaced hardcoded CSI prefix in cursor helper with `ANSI_CSI`.

## Why
- Centralizes ANSI/VT100 handling.
- Reduces duplication.
- Improves maintainability without behavior change.

## Validation
- `make all` succeeds and builds `output/AuriOS.bin`.

Closes #80
