### PR TITLE
fix: update walkman to 0.1.1 in ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Install Walkman
         run: |
-          cargo install --git https://github.com/Auri-OS/walkman.git --tag v0.1.0
+          cargo install --git https://github.com/Auri-OS/walkman.git --tag v0.1.1
 
       - name: Run Walkman Test Suite
         run: |

--- a/tests/integrations/walkman.yaml
+++ b/tests/integrations/walkman.yaml
@@ -19,8 +19,8 @@ shell_interactions:
     - command: "echo Bonjour Walkman"
       expect: "Bonjour Walkman"
 
-    - command: "about"
-      expect: "Version: 0.2"
+    - command: "fetch"
+      expect: "Version:"
 
     - command: "uptime -p"
       expect: "second"


### PR DESCRIPTION
I changed some broken tests as a result of switching the command from about to fetch.

And I changed the Walkman version used in the CI from `0.1.0` to `0.1.1`.