### PR TITLE
fix(mem): typo = instead of - corrupted initial heap block size!!

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ Thank to all the contributors, you are the flame burning in our heart ❤️
 |     <img src="https://github.com/im-nymii.png" width="80" height="80" alt="im-nymii" />     |      [nymii](https://github.com/im-nymii)       |  Founder & Maintainer   |
 |    <img src="https://github.com/llmaddie.png" width="80" height="80" alt="llmaddie 2" />    |      [Maddie](https://github.com/llmaddie)      | Co-Founder & Maintainer |
 |    <img src="https://github.com/pepedinho.png" width="80" height="80" alt="pepedinho" />    |    [pepedinho](https://github.com/pepedinho)    |      Co-Maintainer      |
-|     <img src="https://github.com/kudasaixc.png" width="80" height="80" alt="kudasai" />     |     [kudasai](https://github.com/kudasaixc)     | [![Grand Contributor](https://img.shields.io/badge/👑_GRAND_CONTRIBUTOR_🐐-FFD700?style=for-the-badge&labelColor=8B6914)](https://github.com/kudasaixc)<br>✨🥇 *Bug Hunter Supreme* 🥇✨ |
 |  <img src="https://github.com/swtchcoder.png" width="80" height="80" alt="switchcodeur" />  |  [switchcodeur](https://github.com/swtchcoder)  |       Contributor       |
 |       <img src="https://github.com/proxzr.png" width="80" height="80" alt="proxzr" />       |       [proxzr](https://github.com/proxzr)       |       Contributor       |
 |      <img src="https://github.com/aomitsu.png" width="80" height="80" alt="Aomitsu" />      |      [Aomitsu](https://github.com/aomitsu)      |       Contributor       |
 |       <img src="https://github.com/ivy-js.png" width="80" height="80" alt="ivy-js" />       |       [Ivy-js](https://github.com/ivy-js)       |       Contributor       |
 | <img src="https://github.com/gittihub-jpg.png" width="80" height="80" alt="gittihub-jpg" /> | [gittihub-jpg](https://github.com/gittihub-jpg) |       Contributor       |
 | <img src="https://github.com/jesuiskoriel.png" width="80" height="80" alt="jesuiskoriel" /> | [Jesuiskoriel](https://github.com/Jesuiskoriel) |       Contributor       |
+| <img src="https://github.com/kudasaixc.png" width="80" height="80" alt="kudasaixc" /> | [Kudasai](https://github.com/kudasaixc) |   Contributor & Bug Hunter    |
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -64,18 +64,6 @@ This project demonstrates low-level system programming concepts and serves as a 
 
 Thank to all the contributors, you are the flame burning in our heart ❤️
 
-<div align="center">
-
-<a href="https://github.com/kudasaixc">
-  <img src="https://github.com/kudasaixc.png" width="130" height="130" alt="kudasai" />
-</a>
-
-[![Grand Contributor](https://img.shields.io/badge/👑_GRAND_CONTRIBUTOR_🐐-FFD700?style=for-the-badge&labelColor=8B6914)](https://github.com/kudasaixc)
-
-✨🥇 **[kudasai](https://github.com/kudasaixc)** — *Bug Hunter Supreme* 🥇✨
-
-</div>
-
 <div align="left">
 
 |                                           Profile                                           |                     GitHub                      |          Role           |
@@ -83,6 +71,7 @@ Thank to all the contributors, you are the flame burning in our heart ❤️
 |     <img src="https://github.com/im-nymii.png" width="80" height="80" alt="im-nymii" />     |      [nymii](https://github.com/im-nymii)       |  Founder & Maintainer   |
 |    <img src="https://github.com/llmaddie.png" width="80" height="80" alt="llmaddie 2" />    |      [Maddie](https://github.com/llmaddie)      | Co-Founder & Maintainer |
 |    <img src="https://github.com/pepedinho.png" width="80" height="80" alt="pepedinho" />    |    [pepedinho](https://github.com/pepedinho)    |      Co-Maintainer      |
+|     <img src="https://github.com/kudasaixc.png" width="80" height="80" alt="kudasai" />     |     [kudasai](https://github.com/kudasaixc)     | [![Grand Contributor](https://img.shields.io/badge/👑_GRAND_CONTRIBUTOR_🐐-FFD700?style=for-the-badge&labelColor=8B6914)](https://github.com/kudasaixc)<br>✨🥇 *Bug Hunter Supreme* 🥇✨ |
 |  <img src="https://github.com/swtchcoder.png" width="80" height="80" alt="switchcodeur" />  |  [switchcodeur](https://github.com/swtchcoder)  |       Contributor       |
 |       <img src="https://github.com/proxzr.png" width="80" height="80" alt="proxzr" />       |       [proxzr](https://github.com/proxzr)       |       Contributor       |
 |      <img src="https://github.com/aomitsu.png" width="80" height="80" alt="Aomitsu" />      |      [Aomitsu](https://github.com/aomitsu)      |       Contributor       |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ This project demonstrates low-level system programming concepts and serves as a 
 
 Thank to all the contributors, you are the flame burning in our heart ❤️
 
+<div align="center">
+
+<a href="https://github.com/kudasaixc">
+  <img src="https://github.com/kudasaixc.png" width="130" height="130" alt="kudasai" />
+</a>
+
+[![Grand Contributor](https://img.shields.io/badge/👑_GRAND_CONTRIBUTOR_🐐-FFD700?style=for-the-badge&labelColor=8B6914)](https://github.com/kudasaixc)
+
+✨🥇 **[kudasai](https://github.com/kudasaixc)** — *Bug Hunter Supreme* 🥇✨
+
+</div>
+
 <div align="left">
 
 |                                           Profile                                           |                     GitHub                      |          Role           |

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -43,7 +43,7 @@ void memory_init(void) {
 
 
   head = (block_header_t *) HEAP_VIRT_START;
-  head->size = (heap_end = HEAP_VIRT_START) - HEADER_SIZE;
+  head->size = (heap_end - HEAP_VIRT_START) - HEADER_SIZE;
   head->free = 1;
   head->next = NULL;
   head->prev = NULL;


### PR DESCRIPTION
In memory_init(), line 46 assigns heap_end = HEAP_VIRT_START instead of subtracting, due to a =/- typo. This makes the first free block claim a size of ~3.2 GB (0xCFFFFFF0), so any large malloc returns pointers into unmapped virtual memory (page fault on write). It also resets heap_end to the heap start, so heap_grow() would remap fresh physical frames over existing blocks, corrupting the heap and leaking PMM frames.