### PR TITLE
fix(string): strcat does not null-terminate the result

### DIFF
--- a/src/lib/string.c
+++ b/src/lib/string.c
@@ -44,6 +44,7 @@ int	strcat(char *dest, char *src)
 		dest[a + b] = src[b];
 		b++;
 	}
+	dest[a + b] = '\0';
 	return (*dest);
 }
 


### PR DESCRIPTION
strcat copies the bytes of src after dest but never writes the trailing \0. Any later read of the concatenated string (strlen, terminal_writestring, ...) runs past the end of the buffer into whatever garbage follows, until a stray zero byte is found. The fix writes the terminator before returning.