### PR TITLE
fix(timer): tick must be volatile, sleep() can spin forever

### DIFF
--- a/src/drivers/timer.c
+++ b/src/drivers/timer.c
@@ -4,7 +4,7 @@
 #include "../include/log.h"
 #include <stdint.h>
 
-static uint32_t tick = 0;
+static volatile uint32_t tick = 0;
 static uint32_t frequency = 0;
 
 static void timer_callback(registers_t* regs)


### PR DESCRIPTION
`tick` is written by the timer interrupt handler but read in the `sleep()` busy-wait loop without `volatile`. At -O2 the compiler is allowed to cache `tick` in a register and never reload it, turning `sleep()` into an infinite loop and freezing the whole boot sequence. Whether it works today depends purely on compiler version and flags.