### PR TITLE
fix(pic): unmask cascade IRQ2 when enabling a slave IRQ

### DIFF
--- a/src/cpu/pic.c
+++ b/src/cpu/pic.c
@@ -44,6 +44,9 @@ void pic_unmask_irq(uint8_t irqline)
     if (irqline < 8) {
         port = PIC1_DATA;
     } else {
+        // IRQs 8-15 come in through the slave PIC, wired to the master's
+        // IRQ2 line: the cascade must be unmasked too or they never fire
+        outb(PIC1_DATA, inb(PIC1_DATA) & ~(1 << 2));
         port = PIC2_DATA;
         irqline -= 8;
     }


### PR DESCRIPTION
`pic_remap()` masks every IRQ line (0xFF) including IRQ2, the cascade input for the slave PIC, and nothing ever unmasks it. Any IRQ in the 8-15 range (RTC, PS/2 mouse, ATA, ...) could therefore never be delivered, even after calling `pic_unmask_irq()` for it. This unmasks the cascade line on the master whenever a slave IRQ is enabled.