### PR TITLE
fix(terminal): off-by-one in terminal_set_cursor bounds check

### DIFF
--- a/src/kernel/terminal.c
+++ b/src/kernel/terminal.c
@@ -159,8 +159,8 @@ void terminal_clear_after_cursor(void) {
 }
 
 void terminal_set_cursor(size_t x, size_t y) {
-  if (x > VGA_WIDTH) x = VGA_WIDTH - 1;
-  if (y > VGA_HEIGHT) y = VGA_HEIGHT - 1;
+  if (x >= VGA_WIDTH) x = VGA_WIDTH - 1;
+  if (y >= VGA_HEIGHT) y = VGA_HEIGHT - 1;
 
   terminal_column = x;
   terminal_row = y;


### PR DESCRIPTION
`x == VGA_WIDTH` and `y == VGA_HEIGHT` passed the check, so the next `terminal_putentryat()` could write at index `row * 80 + 80` -- one cell past the end of the line, and past the end of the VGA text buffer when already on the last row.