### PR TITLE
fix(ansi): u16 overflow on oversized CSI parameters

### DIFF
--- a/src/kernel/ainsi.zig
+++ b/src/kernel/ainsi.zig
@@ -79,7 +79,9 @@ export fn ansi_process_char(c: u8) void {
             switch (c) {
                 '0'...'9' => {
                     const n = c - '0';
-                    val.params[val.param_index] = (val.params[val.param_index] * 10) + n;
+                    // saturate instead of overflowing: a u16 overflow would
+                    // trip the ReleaseSafe safety check and hang the kernel
+                    val.params[val.param_index] = val.params[val.param_index] *| 10 +| n;
                 },
                 'J' => {
                     switch (val.params[0]) {


### PR DESCRIPTION
The CSI parameter accumulator multiplied and added with no overflow protection. A sequence like `ESC[99999m` overflows the u16 parameter and, since the Zig objects are built with `-O ReleaseSafe`, trips the safety check and lands in the panic handler: the kernel silently freezes. Saturating arithmetic clamps oversized parameters to 65535 instead of bringing the machine down.