### PR TITLE
fix(shell): one-past-the-end write in argv array when a command has MAX_CMD_ARGS tokens

### DIFF
--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -75,7 +75,7 @@ void debug_trigger_page_fault(void) {
 }
 
 static void shell_execute(char *cmd) {
-  char *args[MAX_CMD_ARGS];
+  char *args[MAX_CMD_ARGS + 1]; // +1 for the NULL terminator written by shell_parse
   int argc = shell_parse(cmd, args);
   if (argc == 0)
     return;


### PR DESCRIPTION
When a command line has 16 or more space-separated tokens, shell_parse writes one pointer past the end of the args array on the stack.

shell_execute declares the array with exactly MAX_CMD_ARGS slots:

```c
char *args[MAX_CMD_ARGS];   // 16 slots, indices 0..15
int argc = shell_parse(cmd, args);
```

shell_parse fills args[0..15] and then always writes the NULL sentinel at args[argc]:

```c
while (cmd[i] != '\0' && argc < MAX_CMD_ARGS) {  // argc can reach 16
    args[argc++] = &cmd[i];
    ...
}
args[argc] = NULL;   // argc == 16 -> writes args[16], past the array
```

So a line of 16 words makes argc reach 16 and args[16] = NULL writes 4 bytes past the array. It's reachable from normal keyboard input, and the tree builds with -fno-stack-protector. It's undefined behaviour; whether it does anything visible depends on the stack layout (see the note below, I could not get it to actually crash on the current toolchain).

Fix is to size the array for the NULL terminator, like a normal argv:

```c
char *args[MAX_CMD_ARGS + 1];
```

No behaviour change for valid input.