### PR TITLE
feat(shell): add poke command to write a byte to memory

### DIFF
--- a/src/include/mm.h
+++ b/src/include/mm.h
@@ -19,5 +19,6 @@ extern void mmu_map_page(uint32_t phys_addr, uint32_t virt_addr, bool is_writeab
 
 extern void mmu_view_mappings(void);
 extern void mmu_debug_peek(uint32_t addr);
+extern void mmu_debug_poke(uint32_t addr, uint8_t value);
 
 #endif

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -93,6 +93,7 @@ static void shell_execute(char *cmd) {
     terminal_writestring("mia     - force a Page Fault for MMU testing\n");
     terminal_writestring("mmap    - print current virtual memory mappings\n");
     terminal_writestring("peek    - read and print memory at a given hex address\n");
+    terminal_writestring("poke    - write a hex byte at a given hex address\n");
     terminal_writestring("echo    - repeats your input to the console\n");
     terminal_writestring("crash   - make the machine freeze (fun cmd)\n\n");
   }
@@ -247,7 +248,16 @@ static void shell_execute(char *cmd) {
   else if (strcmp(cmd_name, "peek") == 0) {
     uint32_t addr = htoi(args[1]);
     mmu_debug_peek(addr);
-	
+
+  }
+  else if (strcmp(cmd_name, "poke") == 0) {
+    if (argc != 3) {
+      terminal_writestring("usage: poke <hex address> <hex value>\n");
+      return;
+    }
+    uint32_t addr = htoi(args[1]);
+    uint8_t value = (uint8_t) htoi(args[2]);
+    mmu_debug_poke(addr, value);
   }
   else if (strcmp(cmd_name, "memtest") == 0) {
     char *a = malloc(32);

--- a/src/mm/mmu.zig
+++ b/src/mm/mmu.zig
@@ -202,7 +202,24 @@ export fn mmu_debug_peek(addr: usize) void {
     serial_write_string("Value found: ");
     print_hex(value);
     serial_write_string("\r\n");
-	
+
+}
+
+export fn mmu_debug_poke(addr: usize, value: u8) void {
+    const ptr = @as(*volatile u8, @ptrFromInt(addr));
+    ptr.* = value;
+
+    terminal_writestring("Wrote ");
+    terminal_print_hex(value);
+    terminal_writestring(" at ");
+    terminal_print_hex(@as(u32, @truncate(addr)));
+    terminal_writestring("\n");
+
+    serial_write_string("\r\n[DEBUG] Poked ");
+    print_hex(value);
+    serial_write_string(" at ");
+    print_hex(addr);
+    serial_write_string("\r\n");
 }
 
 export fn mmu_handle_page_fault(error_code: u32) void {


### PR DESCRIPTION
Adds a poke command to the shell, the write counterpart to the existing peek (read) command.

```
poke <hex address> <hex value>
```

Everything it needs is already there: peek and mmu_debug_peek for the read side (this mirrors them), htoi for hex parsing, and the shell arg parser with the argc check that memdump already uses. So it rounds out the memory debug commands peek / poke / memdump.

What it does:
- mmu_debug_poke(addr, value) in src/mm/mmu.zig writes a byte through a volatile pointer and reports the result on the VGA terminal and the serial log, same shape as mmu_debug_peek.
- prototype in src/include/mm.h
- a poke branch in shell_execute that reuses htoi and checks argc == 3
- one help line

Tested in QEMU (Zig 0.16.0, USE_ZIG path, AURI_TEST_MODE), round-trip works:

```
root@auri-os~$ poke b8000 41
Wrote 0x00000041 at 0x000B8000
root@auri-os~$ peek b8000
Value found : 0x00000041
root@auri-os~$ poke
usage: poke <hex address> <hex value>
```

poke b8000 41 writes 'A' to the top-left VGA cell and peek reads it back.

Like peek, mia and crash, it's a debug primitive that trusts its input (no address validation), consistent with the other debug commands here.