### PR TITLE
feat(shell): add hexdump command for hex + ASCII memory views

### DIFF
--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -61,6 +61,41 @@ void print_unit(uint32_t val, const char *unit, int new_line) {
     terminal_writestring("\n");
 }
 
+// Print a single byte as two uppercase hex digits
+static void print_hex_byte(uint8_t b) {
+  const char *hex = "0123456789ABCDEF";
+  terminal_putchar(hex[(b >> 4) & 0xF]);
+  terminal_putchar(hex[b & 0xF]);
+}
+
+// Dump `len` bytes starting at `addr` as an offset / hex / ASCII table,
+// 16 bytes per row (classic hexdump -C layout).
+static void hexdump(uint32_t addr, uint32_t len) {
+  volatile uint8_t *mem = (volatile uint8_t *) addr;
+
+  for (uint32_t i = 0; i < len; i += 16) {
+    terminal_print_hex(addr + i);
+    terminal_writestring("  ");
+
+    for (uint32_t j = 0; j < 16; j++) {
+      if (i + j < len) {
+        print_hex_byte(mem[i + j]);
+        terminal_putchar(' ');
+      }
+      else {
+        terminal_writestring("   ");
+      }
+    }
+
+    terminal_writestring(" |");
+    for (uint32_t j = 0; j < 16 && i + j < len; j++) {
+      uint8_t c = mem[i + j];
+      terminal_putchar((c >= 32 && c < 127) ? (char) c : '.');
+    }
+    terminal_writestring("|\n");
+  }
+}
+
 void debug_trigger_page_fault(void) {
   terminal_writestring("\n");
   KINFO("[TEST] Attempting to read unmapped memory at 10 MB...");
@@ -93,6 +128,7 @@ static void shell_execute(char *cmd) {
     terminal_writestring("mia     - force a Page Fault for MMU testing\n");
     terminal_writestring("mmap    - print current virtual memory mappings\n");
     terminal_writestring("peek    - read and print memory at a given hex address\n");
+    terminal_writestring("hexdump - dump a memory range as hex + ASCII\n");
     terminal_writestring("echo    - repeats your input to the console\n");
     terminal_writestring("crash   - make the machine freeze (fun cmd)\n\n");
   }
@@ -247,7 +283,16 @@ static void shell_execute(char *cmd) {
   else if (strcmp(cmd_name, "peek") == 0) {
     uint32_t addr = htoi(args[1]);
     mmu_debug_peek(addr);
-	
+
+  }
+  else if (strcmp(cmd_name, "hexdump") == 0) {
+    if (argc != 3) {
+      terminal_writestring("usage: hexdump <hex address> <length>\n");
+      return;
+    }
+    uint32_t addr = htoi(args[1]);
+    uint32_t len = atoi(args[2]);
+    hexdump(addr, len);
   }
   else if (strcmp(cmd_name, "memtest") == 0) {
     char *a = malloc(32);


### PR DESCRIPTION
Adds a hexdump command to the shell.

usage: hexdump <hex address> <length>

It dumps a memory range as the classic offset / hex / ASCII table, 16 bytes per row. peek only reads a single byte and memdump only shows the PMM bitmap, so this fills the gap: the view you actually want when looking at the heap, the page tables or the VGA buffer.

The address is parsed with htoi (hex) and the length with atoi (decimal), reusing the existing helpers, plus terminal_print_hex for the offset column and a small print_hex_byte helper for the byte column. Like peek, mia and crash it trusts its input (no address validation), same as the other debug commands here.

Built and tested locally with the CI setup (Zig 0.16.0 + NASM, USE_ZIG path) and run in QEMU with AURI_TEST_MODE:

    root@auri-os~$ hexdump b8000 48
    0x000B8000  72 0C 6F 0C 6F 0C 74 0C 40 0B 61 0F 75 0F 72 0F  |r.o.o.t.@.a.u.r.|
    0x000B8010  69 0F 2D 0F 6F 0F 73 0F 7E 07 24 0A 20 0A 68 07  |i.-.o.s.~.$. .h.|
    0x000B8020  65 07 78 07 64 07 75 07 6D 07 70 07 20 07 62 07  |e.x.d.u.m.p. .b.|
    root@auri-os~$ hexdump
    usage: hexdump <hex address> <length>

That dump is the VGA text buffer, so the ASCII column shows the prompt text with the attribute bytes rendering as dots.