### PR TITLE
feat(shell): add reboot and poweroff commands

### DIFF
--- a/src/include/io.h
+++ b/src/include/io.h
@@ -7,6 +7,10 @@ static inline void outb(uint16_t port, uint8_t value) {
     __asm__ volatile ("outb %0, %1" : : "a"(value), "Nd"(port));
 }
 
+static inline void outw(uint16_t port, uint16_t value) {
+    __asm__ volatile ("outw %0, %1" : : "a"(value), "Nd"(port));
+}
+
 static inline uint8_t inb(uint16_t port) {
     uint8_t ret;
     __asm__ volatile ("inb %1, %0" : "=a"(ret) : "Nd"(port));

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -149,19 +149,15 @@ static void shell_execute(char *cmd) {
   }
   else if (strcmp(cmd_name, "reboot") == 0) {
     terminal_writestring("Rebooting...\n");
-    // Wait for the 8042 input buffer to drain, then pulse the CPU reset line.
     while (inb(0x64) & 0x02)
       ;
     outb(0x64, 0xFE);
-    // If the reset did not fire, fall back to a halt.
     asm volatile("cli; hlt");
   }
-  else if (strcmp(cmd_name, "poweroff") == 0) {
+  else if (strcmp(cmd_name, "exit") == 0) {
     terminal_writestring("Powering off...\n");
-    // ACPI shutdown as exposed by QEMU (0x604) and older QEMU / Bochs (0xB004).
     outw(0x604, 0x2000);
     outw(0xB004, 0x2000);
-    // No virtual power management available: halt instead.
     asm volatile("cli; hlt");
   }
   else if (strcmp(cmd_name, "uptime") == 0) {

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -2,6 +2,7 @@
 #include "../include/colors.h"
 #include "../include/fetch.h"
 #include "../include/integer.h"
+#include "../include/io.h"
 #include "../include/log.h"
 #include "../include/memory.h"
 #include "../include/mm.h"
@@ -94,6 +95,8 @@ static void shell_execute(char *cmd) {
     terminal_writestring("mmap    - print current virtual memory mappings\n");
     terminal_writestring("peek    - read and print memory at a given hex address\n");
     terminal_writestring("echo    - repeats your input to the console\n");
+    terminal_writestring("reboot  - restart the machine\n");
+    terminal_writestring("poweroff- shut the machine down (QEMU/Bochs)\n");
     terminal_writestring("crash   - make the machine freeze (fun cmd)\n\n");
   }
   else if (strcmp(cmd_name, "clear") == 0) {
@@ -143,6 +146,23 @@ static void shell_execute(char *cmd) {
     asm volatile("cli");
     for (;;)
       asm volatile("hlt");
+  }
+  else if (strcmp(cmd_name, "reboot") == 0) {
+    terminal_writestring("Rebooting...\n");
+    // Wait for the 8042 input buffer to drain, then pulse the CPU reset line.
+    while (inb(0x64) & 0x02)
+      ;
+    outb(0x64, 0xFE);
+    // If the reset did not fire, fall back to a halt.
+    asm volatile("cli; hlt");
+  }
+  else if (strcmp(cmd_name, "poweroff") == 0) {
+    terminal_writestring("Powering off...\n");
+    // ACPI shutdown as exposed by QEMU (0x604) and older QEMU / Bochs (0xB004).
+    outw(0x604, 0x2000);
+    outw(0xB004, 0x2000);
+    // No virtual power management available: halt instead.
+    asm volatile("cli; hlt");
   }
   else if (strcmp(cmd_name, "uptime") == 0) {
     uint32_t ticks = get_tick();

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -96,7 +96,7 @@ static void shell_execute(char *cmd) {
     terminal_writestring("peek    - read and print memory at a given hex address\n");
     terminal_writestring("echo    - repeats your input to the console\n");
     terminal_writestring("reboot  - restart the machine\n");
-    terminal_writestring("poweroff- shut the machine down (QEMU/Bochs)\n");
+    terminal_writestring("exit.   - shut the machine down (QEMU/Bochs)\n");
     terminal_writestring("crash   - make the machine freeze (fun cmd)\n\n");
   }
   else if (strcmp(cmd_name, "clear") == 0) {


### PR DESCRIPTION
Adds two machine lifecycle commands. Until now the only way to leave the shell was crash, which just halts the CPU.

reboot waits for the 8042 input buffer to drain, then pulses the CPU reset line with outb(0x64, 0xFE).

poweroff triggers an ACPI shutdown through the ports QEMU (0x604) and older QEMU / Bochs (0xB004) expose, which cleanly powers the VM off.

Both fall back to a halt if the hardware action does not fire. Also adds a 16-bit outw helper to io.h for the ACPI writes.

Note: poweroff relies on the virtual ACPI device, so it powers off under QEMU/Bochs (their whole workflow); on real hardware a proper ACPI implementation would be needed, there it just halts.

Built and tested locally with the CI setup (Zig 0.16.0 + NASM, USE_ZIG path) in QEMU:

- reboot: the boot banner (Starting AuriOS boot sequence) appears a second time, so the machine really reset.
- poweroff: QEMU exits on its own about 4s after the command with stdin still open, so the ACPI shutdown fired (not just an EOF).