### PR TITLE
fix(shell): check argc in peek command

### DIFF
--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -262,6 +262,10 @@ static void shell_execute(char *cmd) {
     mmu_view_mappings();
   }
   else if (strcmp(cmd_name, "peek") == 0) {
+    if (argc != 2) {
+      terminal_writestring("usage: peek <hex address>\n");
+      return;
+    }
     uint32_t addr = htoi(args[1]);
     mmu_debug_peek(addr);
 


### PR DESCRIPTION
`peek` reads `args[1]` without checking `argc`, so running `peek` with no argument dereferences NULL inside `htoi`.  
It doesn't fault: page 0 is identity-mapped (mmu.zig:56-64), so it silently parses garbage and dumps an arbitrary address.  
Adds the same `argc` guard already used by `memdump` and `poke`.
