### PR TITLE
feat: implement tab completion for shell commands

### DIFF
--- a/src/drivers/keyboard.c
+++ b/src/drivers/keyboard.c
@@ -83,7 +83,6 @@ void keyboard_callback(registers_t *regs)
         ctrl_pressed = 0;
         return;
     }
-
     
     if (scancode & 0x80)
         return;
@@ -101,6 +100,11 @@ void keyboard_callback(registers_t *regs)
     }
     char c ;
 
+    if (scancode == 0x0F) {
+        shell_handle_key('\t');
+        return;
+    }
+    
     if (shift_pressed)
         c = scancode_to_ascii_shift[scancode];
     else

--- a/src/include/string.h
+++ b/src/include/string.h
@@ -5,7 +5,7 @@
 
 size_t strlen(const char* str);
 int strcmp(const char *s1, const char *s2);
-int strncmp(char *s1, char *s2, unsigned int n);
+int strncmp(const char *s1, char *s2, unsigned int n);
 int	strcat(char *dest, char *src);
 char *strncat(char *dest, char *src, unsigned int nb);
 int str_is_uppercase(char *str);

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -18,6 +18,13 @@
 static char buffer[BUFFER_SIZE];
 static int buffer_pos = 0;
 
+static void command_completion(void);
+static void shell_insert_completion(const char *text, int len, int add_space);
+
+static const char *command_list[] = {
+    "help", "fetch", "clear", "uptime", "memdump", "memtest", "mia",
+    "mmap", "peek",  "poke",  "echo",  "reboot",  "exit",   "crash", NULL};
+
 void shell_init(void) {
   // Flush any keystrokes captured by the keyboard interrupt during boot.
   memset(buffer, 0, BUFFER_SIZE);
@@ -100,7 +107,7 @@ static void shell_execute(char *cmd) {
     terminal_writestring("poke    - write a hex byte at a given hex address\n");
     terminal_writestring("echo    - repeats your input to the console\n");
     terminal_writestring("reboot  - restart the machine\n");
-    terminal_writestring("exit.   - shut the machine down (QEMU/Bochs)\n");
+    terminal_writestring("exit    - shut the machine down (QEMU/Bochs)\n");
     terminal_writestring("crash   - make the machine freeze (fun cmd)\n\n");
   }
   else if (strcmp(cmd_name, "clear") == 0) {
@@ -294,11 +301,86 @@ static void shell_execute(char *cmd) {
     print_unit((uint32_t) (uintptr_t) c, "(addr)", 1);
     free(b);
     free(c);
-  }
-  else {
+  } else {
     terminal_writestring("command not found: ");
     terminal_writestring(cmd_name);
     terminal_putchar('\n');
+  } 
+}
+
+static int command_recognition(const char *a, const char *b) {
+  int i = 0;
+  while (a[i] && b[i] && a[i] == b[i])
+    i++;
+  return i;
+}
+
+static void command_completion(void) {
+  int i = 0;
+  int prefix_len = buffer_pos;
+  const char *matches[32];
+  int n = 0;
+  int lcp = -1;
+
+  while (i < buffer_pos) 
+    if (buffer[i++] == ' ')
+      return;
+
+  i = 0;
+
+  while (command_list[i] != NULL) {
+    if (strncmp(command_list[i], buffer, prefix_len) == 0) {
+      if (n < 32) 
+        matches[n++] = command_list[i];
+      if (lcp < 0)
+        lcp = (int) strlen(command_list[i]);
+      else
+        lcp = command_recognition(matches[0], command_list[i]) < lcp ? command_recognition(matches[0], command_list[i]) : lcp;
+    }
+    i++;
+  }
+if (n == 0) 
+  return;
+
+if (n == 1) {
+  shell_insert_completion(matches[0], (int) strlen(matches[0]), 1);
+  return;
+}
+
+if (lcp > prefix_len) {
+  shell_insert_completion(matches[0], lcp, 0);
+  return;
+}
+
+terminal_putchar('\n');
+for (i = 0; i < n; i++) {
+  terminal_writestring(matches[i]);
+  terminal_writestring("  ");
+}
+terminal_putchar('\n');
+terminal_writestring(cli_nav);
+terminal_writestring(buffer);
+
+}
+
+static void shell_insert_completion(const char *text, int len, int add_space) {
+  int i = buffer_pos;
+  while (i < len) {
+    if (i >= BUFFER_SIZE - 2) break;
+    char ch = text[i];
+    buffer[i] = ch;
+    terminal_putchar(ch);
+    i++;
+  }
+
+  buffer_pos = len;
+  buffer[buffer_pos] = '\0';
+
+  if (add_space && buffer_pos < BUFFER_SIZE - 1) {
+    buffer[buffer_pos] = ' ';
+    buffer_pos++;
+    buffer[buffer_pos] = '\0';
+    terminal_putchar(' ');
   }
 }
 
@@ -308,15 +390,13 @@ void shell_handle_key(char c) {
     buffer_pos = 0;
     shell_init();
     return;
-  }
-  if (c == '\n') {
+  } if (c == '\n') {
     terminal_putchar('\n');
     shell_execute(buffer);
     buffer[0] = '\0';
     buffer_pos = 0;
     terminal_writestring(cli_nav);
-  }
-  else if (c == '\b') {
+  } else if (c == '\b') {
     if (buffer_pos > 0) {
       int len = (int) strlen(buffer);
       int tail = len - buffer_pos; 
@@ -328,20 +408,23 @@ void shell_handle_key(char c) {
       terminal_putchar(' ');
       terminal_move_cursor(-(tail + 1));
     }
-  }
-  else {
-
+  } else if (c == '\t') {
+    command_completion();
+  } else {
     int len = (int) strlen(buffer);
-	if(len < BUFFER_SIZE - 1) {
-		int tail = len - buffer_pos;
-		for (int x = len; x > buffer_pos; x--)
-			buffer[x] = buffer[x - 1];
-		buffer[buffer_pos] = c;
-		buffer[len + 1] = '\0';
-		terminal_writestring(&buffer[buffer_pos]);
-		buffer_pos++;
-		terminal_move_cursor(-tail);
-	}
+
+    if(len < BUFFER_SIZE - 1) {
+      int tail = len - buffer_pos;
+
+      for (int x = len; x > buffer_pos; x--)
+        buffer[x] = buffer[x - 1];
+
+      buffer[buffer_pos] = c;
+      buffer[len + 1] = '\0';
+      terminal_writestring(&buffer[buffer_pos]);
+      buffer_pos++;
+      terminal_move_cursor(-tail);
+    }
   }
 }
 

--- a/src/lib/string.c
+++ b/src/lib/string.c
@@ -19,7 +19,7 @@ int strcmp(const char *s1, const char *s2)
 }
 
 // Compare the first n byte of two string between them
-int	strncmp(char *s1, char *s2, unsigned int n)
+int	strncmp(const char *s1, char *s2, unsigned int n)
 {
 	unsigned int i = 0;
 	if (n == 0)


### PR DESCRIPTION
# Related to : https://github.com/Auri-OS/AuriOS/issues/100

This pull request adds tab-based command completion to the shell, allowing users to auto-complete commands by pressing Tab. It also introduces supporting functions and makes minor improvements to code style and function signatures.

**Shell command completion:**

* Added tab key handling in the keyboard driver (`keyboard.c`) to trigger command completion in the shell (`shell_handle_key('\t')`).
* Implemented command completion logic in the shell, including functions for recognizing command prefixes, finding matches, and inserting completions (`command_completion`, `shell_insert_completion`, and `command_recognition` in `shell.c`). [[1]](diffhunk://#diff-86a30a836de2d5968a90cdc168b0c388e1f2d4d5bda8bf43326a005a49b563faR21-R27) [[2]](diffhunk://#diff-86a30a836de2d5968a90cdc168b0c388e1f2d4d5bda8bf43326a005a49b563faL297-R399) [[3]](diffhunk://#diff-86a30a836de2d5968a90cdc168b0c388e1f2d4d5bda8bf43326a005a49b563faL331-R421)
* Added a list of available commands for completion (`command_list` in `shell.c`).

**Code improvements and fixes:**

* Fixed a typo in the help text for the `exit` command.
* Improved formatting and style in the keyboard callback and shell handler functions. [[1]](diffhunk://#diff-e0d449fe88a1a2ed28ec2ed0551631b9edd6b9cd04c2a423dfd501c678024eb0L87) [[2]](diffhunk://#diff-86a30a836de2d5968a90cdc168b0c388e1f2d4d5bda8bf43326a005a49b563faL297-R399) [[3]](diffhunk://#diff-86a30a836de2d5968a90cdc168b0c388e1f2d4d5bda8bf43326a005a49b563faL331-R421)

**Function signature corrections:**

* Updated the signature of `strncmp` in both `string.h` and `string.c` to use `const char *` for the first argument. [[1]](diffhunk://#diff-aea7e071810c24807245f61006a4eec5be0f39f9634f5aad2fa2f0c8d120f30cL8-R8) [[2]](diffhunk://#diff-c422a364cb2ecb2f5baac647d0e80e001aa65eaacb094b4a5bfdaa2c2e4f879cL22-R22)