### PR TITLE
refacto: changing nav-cli design

### DIFF
--- a/src/include/shell.h
+++ b/src/include/shell.h
@@ -2,8 +2,8 @@
 #define SHELL_H
 
 #define cli_nav                                                                          \
-  COLOR_RED_BRIGHT "root" COLOR_CYAN_BRIGHT "@" COLOR_WHITE_BRIGHT "auri-os" COLOR_RESET \
-                   "~" COLOR_GREEN_BRIGHT "$ " COLOR_RESET
+  COLOR_WHITE_BRIGHT "[" COLOR_RED_BRIGHT "root" COLOR_CYAN_BRIGHT "@" COLOR_WHITE_BRIGHT "auri-os" COLOR_RESET \
+                   " ~" COLOR_WHITE_BRIGHT "]" COLOR_GREEN_BRIGHT "$ " COLOR_RESET
 void shell_init(void);
 void shell_handle_key(char c);
 void shell_history(int a); // a for arrow


### PR DESCRIPTION
This pull request updates the command-line interface (CLI) prompt styling in the `shell.h` header. The prompt now includes square brackets around the user and host information and applies consistent coloring.

Prompt appearance update:

* [`src/include/shell.h`](diffhunk://#diff-32a624bb0210e39c5271caf5880e85f8d9c4dc82195c417f1b02c3e70792afcdL5-R6): Modified the `cli_nav` macro to display the prompt as `[root@auri-os ~] with improved color formatting for better readability.