### PR TITLE
refacto: reorganize command structure and implement command functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 AS = nasm
 
 # Source files
-C_SOURCES = $(wildcard src/kernel/*.c) $(wildcard src/cpu/*.c) $(wildcard src/lib/*.c) $(wildcard src/drivers/*.c)
+C_SOURCES = $(wildcard src/kernel/*.c) $(wildcard src/cpu/*.c) $(wildcard src/lib/*.c) $(wildcard src/drivers/*.c) $(wildcard src/commands/*.c)
 S_SOURCES = $(wildcard src/boot/*.s)
 ASM_SOURCES = $(wildcard src/cpu/*.asm)
 ZIG_SOURCES = $(wildcard src/kernel/*.zig) $(wildcard src/mm/*.zig)

--- a/src/commands/crash.c
+++ b/src/commands/crash.c
@@ -1,0 +1,7 @@
+#include "../include/commands.h"
+
+void crash(void) {
+    asm volatile("cli");
+    for (;;)
+        asm volatile("hlt");
+}

--- a/src/commands/echo.c
+++ b/src/commands/echo.c
@@ -1,0 +1,36 @@
+#include "../include/terminal.h"
+#include "../include/string.h"
+#include "../include/commands.h"
+
+void echo(void *args, int argc) {
+    char **argv = (char **)args;
+    int j = 1;
+    int skip_newline = 0;
+
+    while (j < argc && argv[j][0] == '-') {
+        if (strcmp(argv[j], "-n") == 0) {
+            skip_newline = 1;
+        }
+        else if (strcmp(argv[j], "-h") == 0) {
+            terminal_writestring("echo - repeats your input to the console\n\n");
+            terminal_writestring("-h   - show this command\n");
+            terminal_writestring("-n   - do not output the trailing new line");
+            terminal_writestring("\n");
+            return;
+        }
+        else {
+            // No more recognized args
+            break;
+        }
+        j++;
+    }
+
+    while (j < argc) {
+        terminal_writestring(argv[j]);
+        terminal_writestring(" ");
+        j++;
+    }
+
+    if (!skip_newline)
+        terminal_writestring("\n");
+}

--- a/src/commands/fetch.c
+++ b/src/commands/fetch.c
@@ -1,0 +1,45 @@
+#include "../include/terminal.h"
+#include "../include/colors.h"
+#include "../include/fetch.h"
+#include "../include/commands.h"
+
+/*
+To modify the info strings displayed to the right of the fetch ASCII art,
+edit src/include/fetch.h
+*/
+void fetch(void) {
+    terminal_writestring(
+        "\n          " COLOR_WHITE_BRIGHT ".**." COLOR_RESET "                 \n");
+    ///
+    terminal_writestring("         " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "=" COLOR_BLUE_BRIGHT
+                         "###" COLOR_WHITE_BRIGHT "." COLOR_RESET "             " fetch_user "\n");
+    ///
+    terminal_writestring("        " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "==" COLOR_WHITE_BRIGHT
+                         "." COLOR_BLUE_BRIGHT "##%" COLOR_WHITE_BRIGHT "." COLOR_RESET
+                         "            --------------\n");
+    ///
+    terminal_writestring("       " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "===" COLOR_WHITE_BRIGHT
+                         "." COLOR_BLUE_BRIGHT "###" COLOR_WHITE_BRIGHT "." COLOR_RESET
+                         "            " fetch_kernel_name "\n");
+    ///
+    terminal_writestring(
+        "      " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "=====" COLOR_BLUE_BRIGHT
+        "###" COLOR_WHITE_BRIGHT "." COLOR_RESET "            " fetch_version "\n");
+    ///
+    terminal_writestring("     " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT
+                         "======" COLOR_WHITE_BRIGHT "." COLOR_BLUE_BRIGHT "###" COLOR_WHITE_BRIGHT
+                         "." COLOR_RESET "           " fetch_release_date "\n");
+    ///
+    terminal_writestring(
+        "    " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "======" COLOR_WHITE_BRIGHT
+        ".." COLOR_BLUE_BRIGHT "###" COLOR_WHITE_BRIGHT "." COLOR_RESET "         \n");
+    ///
+    terminal_writestring(
+        "   " COLOR_WHITE_BRIGHT ".===.    ." COLOR_BLUE_BRIGHT "###" COLOR_WHITE_BRIGHT
+        "." COLOR_RESET "           " bg_color_bright "\n");
+    ///
+    terminal_writestring(
+        "             " COLOR_WHITE_BRIGHT ".***." COLOR_RESET "          " bg_color "\n\n");
+    ///
+    terminal_writestring("Type 'help' for available commands\n\n");
+}

--- a/src/commands/help.c
+++ b/src/commands/help.c
@@ -1,0 +1,20 @@
+#include "../include/terminal.h"
+#include "../include/commands.h"
+
+void help(void) {
+    terminal_writestring("\nhelp  - show this command\n");
+    terminal_writestring("fetch   - show informations about AuriOS\n");
+    terminal_writestring("clear   - clear the terminal (can be done with CTRL + L)\n");
+    terminal_writestring(
+        "uptime  - show uptime since machine started\n           -h for options help\n");
+    terminal_writestring("memdump - print the PMM Bitmap in the log\n");
+    terminal_writestring("memtest - allocate/free on the kernel heap (heap self-test)\n");
+    terminal_writestring("mia     - force a Page Fault for MMU testing\n");
+    terminal_writestring("mmap    - print current virtual memory mappings\n");
+    terminal_writestring("peek    - read and print memory at a given hex address\n");
+    terminal_writestring("poke    - write a hex byte at a given hex address\n");
+    terminal_writestring("echo    - repeats your input to the console\n");
+    terminal_writestring("reboot  - restart the machine\n");
+    terminal_writestring("exit    - shut the machine down (QEMU/Bochs)\n");
+    terminal_writestring("crash   - make the machine freeze (fun cmd)\n\n");
+}

--- a/src/commands/memdump.c
+++ b/src/commands/memdump.c
@@ -1,0 +1,18 @@
+#include "../include/terminal.h"
+#include "../include/integer.h"
+#include "../include/mm.h"
+#include "../include/commands.h"
+
+void memdump(void *args, int argc) {
+    char **argv = (char **)args;
+    if (argc != 2) {
+        terminal_writestring("usage: memdump <size>\n");
+        return;
+    }
+    int size = atoi(argv[1]);
+    if (size < 1 || size > 16384) {
+        terminal_writestring("memdump: size must be between 1-16384\n");
+        return;
+    }
+    pmm_dump_bitmap(size);
+}

--- a/src/commands/memtest.c
+++ b/src/commands/memtest.c
@@ -1,0 +1,19 @@
+#include "../include/types.h"
+#include "../include/terminal.h"
+#include "../include/memory.h"
+#include "../include/string.h"
+#include "../include/commands.h"
+
+void memtest(void) {
+    char *a = malloc(32);
+    char *b = malloc(100);
+    strlcpy(a, "heap ok", 8);
+    terminal_writestring("\nalloc a: ");
+    terminal_writestring(a);
+    free(a);
+    char *c = malloc(16);
+    terminal_writestring("\nreuse : ");
+    print_unit((uint32_t) (uintptr_t) c, "(addr)", 1);
+    free(b);
+    free(c);
+}

--- a/src/commands/mia.c
+++ b/src/commands/mia.c
@@ -1,0 +1,17 @@
+#include "../include/types.h"
+#include "../include/terminal.h"
+#include "../include/log.h"
+#include "../include/commands.h"
+
+void mia(void) {
+    terminal_writestring("\n");
+    KINFO("[TEST] Attempting to read unmapped memory at 10 MB...");
+
+    uint32_t *illegal_ptr = (uint32_t *) 0x00A00000;
+
+    volatile uint32_t crash_value = *illegal_ptr;
+
+    (void) crash_value;
+
+    KPANIC("MMU failed to block unmapped memory access!");
+}

--- a/src/commands/peek.c
+++ b/src/commands/peek.c
@@ -1,0 +1,15 @@
+#include "../include/types.h"
+#include "../include/terminal.h"
+#include "../include/integer.h"
+#include "../include/mm.h"
+#include "../include/commands.h"
+
+void peek(void *args, int argc) {
+    char **argv = (char **)args;
+    if (argc != 2) {
+        terminal_writestring("usage: peek <hex address>\n");
+        return;
+    }
+    uint32_t addr = htoi(argv[1]);
+    mmu_debug_peek(addr);
+}

--- a/src/commands/poke.c
+++ b/src/commands/poke.c
@@ -1,0 +1,16 @@
+#include "../include/types.h"
+#include "../include/terminal.h"
+#include "../include/integer.h"
+#include "../include/mm.h"
+#include "../include/commands.h"
+
+void poke(void *args, int argc) {
+    char **argv = (char **)args;
+    if (argc != 3) {
+        terminal_writestring("usage: poke <hex address> <hex value>\n");
+        return;
+    }
+    uint32_t addr = htoi(argv[1]);
+    uint8_t value = (uint8_t) htoi(argv[2]);
+    mmu_debug_poke(addr, value);
+}

--- a/src/commands/poweroff.c
+++ b/src/commands/poweroff.c
@@ -1,0 +1,10 @@
+#include "../include/terminal.h"
+#include "../include/io.h"
+#include "../include/commands.h"
+
+void poweroff(void) {
+    terminal_writestring("Powering off...\n");
+    outw(0x604, 0x2000);
+    outw(0xB004, 0x2000);
+    asm volatile("cli; hlt");
+}

--- a/src/commands/reboot.c
+++ b/src/commands/reboot.c
@@ -1,0 +1,11 @@
+#include "../include/terminal.h"
+#include "../include/io.h"
+#include "../include/commands.h"
+
+void reboot(void) {
+    terminal_writestring("Rebooting...\n");
+    while (inb(0x64) & 0x02)
+        ;
+    outb(0x64, 0xFE);
+    asm volatile("cli; hlt");
+}

--- a/src/commands/uptime.c
+++ b/src/commands/uptime.c
@@ -1,0 +1,63 @@
+#include "../include/types.h"
+#include "../include/timer.h"
+#include "../include/terminal.h"
+#include "../include/string.h"
+#include "../include/commands.h"
+
+void uptime(void *args, int argc) {
+    char **argv = (char **)args;
+    uint32_t ticks = get_tick();
+    uint32_t total_seconds = ticks / 1000;
+    uint32_t seconds = total_seconds % 60;
+
+    uint32_t total_minutes = total_seconds / 60;
+    uint32_t minutes = total_minutes % 60;
+
+    uint32_t hours = total_minutes / 60;
+
+    int j = 1;
+    int raw = 0;
+    int sec = 0;
+    int pretty = 0;
+    while (j < argc && argv[j][0] == '-') {
+        if (strcmp(argv[j], "-h") == 0) {
+            terminal_writestring("uptime - show uptime since machine started\n");
+            terminal_writestring("-h     - show this message\n");
+            terminal_writestring("-r     - show uptime in miliseconds\n");
+            terminal_writestring("-s     - show uptime in seconds\n");
+            terminal_writestring("-p     - show uptime in a pretty format\n");
+            return;
+        }
+        else if (strcmp(argv[j], "-r") == 0)
+            raw = 1;
+        else if (strcmp(argv[j], "-s") == 0)
+            sec = 1;
+        else if (strcmp(argv[j], "-p") == 0)
+            pretty = 1;
+        else {
+            break;
+        }
+        j++;
+    }
+
+    if (raw == 1) {
+        print_unit(ticks, "ms", 1);
+    }
+    else if (sec == 1) {
+        print_unit(total_seconds, "s", 1);
+    }
+    else if (pretty == 1) {
+        terminal_writestring("Current Uptime: \n");
+        if (hours != 0)
+            print_unit(hours, hours > 1 ? " hours" : " hour", 1);
+        print_unit(minutes, minutes > 1 ? " minutes" : " minute", 1);
+        print_unit(seconds, seconds > 1 ? " seconds" : " second", 1);
+        terminal_writestring("\n");
+    }
+    else {
+        terminal_writestring("Current Uptime: ");
+        print_unit(hours, "h ", 0);
+        print_unit(minutes, "m ", 0);
+        print_unit(seconds, "s", 1);
+    }
+}

--- a/src/include/commands.h
+++ b/src/include/commands.h
@@ -1,0 +1,21 @@
+#ifndef COMMANDS_D
+#define COMMANDS_D
+
+#include "types.h"
+
+void print_unit(uint32_t val, const char *unit, int new_line);
+
+void help(void);
+void fetch(void);
+void crash(void);
+void reboot(void);
+void poweroff(void);
+void mia(void);
+void memtest(void);
+void uptime(void *args, int argc);
+void echo(void *args, int argc);
+void memdump(void *args, int argc);
+void peek(void *args, int argc);
+void poke(void *args, int argc);
+
+#endif

--- a/src/kernel/shell.c
+++ b/src/kernel/shell.c
@@ -10,6 +10,7 @@
 #include "../include/terminal.h"
 #include "../include/timer.h"
 #include "../include/history.h"
+#include "../include/commands.h"
 #define BUFFER_SIZE 256
 #define MAX_CMD_ARGS 16
 #define MAX_HISTORY_SIZE 16
@@ -70,19 +71,6 @@ void print_unit(uint32_t val, const char *unit, int new_line) {
     terminal_writestring("\n");
 }
 
-void debug_trigger_page_fault(void) {
-  terminal_writestring("\n");
-  KINFO("[TEST] Attempting to read unmapped memory at 10 MB...");
-
-  uint32_t *illegal_ptr = (uint32_t *) 0x00A00000;
-
-  volatile uint32_t crash_value = *illegal_ptr;
-
-  (void) crash_value;
-
-  KPANIC("MMU failed to block unmapped memory access!");
-}
-
 static void shell_execute(char *cmd) {
   history_push(cmd);
   char *args[MAX_CMD_ARGS + 1]; // +1 for the NULL terminator written by shell_parse
@@ -93,218 +81,46 @@ static void shell_execute(char *cmd) {
   char *cmd_name = args[0]; 
 
   if (strcmp(cmd_name, "help") == 0) {
-    terminal_writestring("\nhelp  - show this command\n");
-    terminal_writestring("fetch   - show informations about AuriOS\n");
-    terminal_writestring("clear   - clear the terminal (can be done with CTRL + L)\n");
-    terminal_writestring(
-        "uptime  - show uptime since machine started\n           -h for options help\n");
-    terminal_writestring("memdump - print the PMM Bitmap in the log\n");
-    terminal_writestring("memtest - allocate/free on the kernel heap (heap self-test)\n");
-    terminal_writestring("mia     - force a Page Fault for MMU testing\n");
-    terminal_writestring("mmap    - print current virtual memory mappings\n");
-    terminal_writestring("peek    - read and print memory at a given hex address\n");
-    terminal_writestring("poke    - write a hex byte at a given hex address\n");
-    terminal_writestring("echo    - repeats your input to the console\n");
-    terminal_writestring("reboot  - restart the machine\n");
-    terminal_writestring("exit    - shut the machine down (QEMU/Bochs)\n");
-    terminal_writestring("crash   - make the machine freeze (fun cmd)\n\n");
+    help();
   }
   else if (strcmp(cmd_name, "clear") == 0) {
     terminal_clear();
   }
-  /*
-  To modify the info strings displayed to the right of the fetch ASCII art,
-  edit src/include/fetch.h
-  */
   else if (strcmp(cmd_name, "fetch") == 0) {
-    terminal_writestring(
-        "\n          " COLOR_WHITE_BRIGHT ".**." COLOR_RESET "                 \n");
-    ///
-    terminal_writestring("         " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "=" COLOR_BLUE_BRIGHT
-                         "###" COLOR_WHITE_BRIGHT "." COLOR_RESET "             " fetch_user "\n");
-    ///
-    terminal_writestring("        " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "==" COLOR_WHITE_BRIGHT
-                         "." COLOR_BLUE_BRIGHT "##%" COLOR_WHITE_BRIGHT "." COLOR_RESET
-                         "            --------------\n");
-    ///
-    terminal_writestring("       " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "===" COLOR_WHITE_BRIGHT
-                         "." COLOR_BLUE_BRIGHT "###" COLOR_WHITE_BRIGHT "." COLOR_RESET
-                         "            " fetch_kernel_name "\n");
-    ///
-    terminal_writestring(
-        "      " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "=====" COLOR_BLUE_BRIGHT
-        "###" COLOR_WHITE_BRIGHT "." COLOR_RESET "            " fetch_version "\n");
-    ///
-    terminal_writestring("     " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT
-                         "======" COLOR_WHITE_BRIGHT "." COLOR_BLUE_BRIGHT "###" COLOR_WHITE_BRIGHT
-                         "." COLOR_RESET "           " fetch_release_date "\n");
-    ///
-    terminal_writestring(
-        "    " COLOR_WHITE_BRIGHT "." COLOR_CYAN_BRIGHT "======" COLOR_WHITE_BRIGHT
-        ".." COLOR_BLUE_BRIGHT "###" COLOR_WHITE_BRIGHT "." COLOR_RESET "         \n");
-    ///
-    terminal_writestring(
-        "   " COLOR_WHITE_BRIGHT ".===.    ." COLOR_BLUE_BRIGHT "###" COLOR_WHITE_BRIGHT
-        "." COLOR_RESET "           " bg_color_bright "\n");
-    ///
-    terminal_writestring(
-        "             " COLOR_WHITE_BRIGHT ".***." COLOR_RESET "          " bg_color "\n\n");
-    ///
-    terminal_writestring("Type 'help' for available commands\n\n");
+    fetch();
   }
   else if (strcmp(cmd_name, "crash") == 0) {
-    asm volatile("cli");
-    for (;;)
-      asm volatile("hlt");
+    crash();
   }
   else if (strcmp(cmd_name, "reboot") == 0) {
-    terminal_writestring("Rebooting...\n");
-    while (inb(0x64) & 0x02)
-      ;
-    outb(0x64, 0xFE);
-    asm volatile("cli; hlt");
+    reboot();
   }
   else if (strcmp(cmd_name, "exit") == 0) {
-    terminal_writestring("Powering off...\n");
-    outw(0x604, 0x2000);
-    outw(0xB004, 0x2000);
-    asm volatile("cli; hlt");
+    poweroff();
   }
   else if (strcmp(cmd_name, "uptime") == 0) {
-    uint32_t ticks = get_tick();
-    uint32_t total_seconds = ticks / 1000;
-    uint32_t seconds = total_seconds % 60;
-
-    uint32_t total_minutes = total_seconds / 60;
-    uint32_t minutes = total_minutes % 60;
-
-    uint32_t hours = total_minutes / 60;
-
-    int j = 1;
-    int raw = 0;
-    int sec = 0;
-    int pretty = 0;
-    while (j < argc && args[j][0] == '-') {
-      if (strcmp(args[j], "-h") == 0) {
-        terminal_writestring("uptime - show uptime since machine started\n");
-        terminal_writestring("-h     - show this message\n");
-        terminal_writestring("-r     - show uptime in miliseconds\n");
-        terminal_writestring("-s     - show uptime in seconds\n");
-        terminal_writestring("-p     - show uptime in a pretty format\n");
-        return;
-      }
-      else if (strcmp(args[j], "-r") == 0)
-        raw = 1;
-      else if (strcmp(args[j], "-s") == 0)
-        sec = 1;
-      else if (strcmp(args[j], "-p") == 0)
-        pretty = 1;
-      else {
-        break;
-      }
-      j++;
-    }
-
-    if (raw == 1) {
-      print_unit(ticks, "ms", 1);
-    }
-    else if (sec == 1) {
-      print_unit(total_seconds, "s", 1);
-    }
-    else if (pretty == 1) {
-      terminal_writestring("Current Uptime: \n");
-      if (hours != 0)
-        print_unit(hours, hours > 1 ? " hours" : " hour", 1);
-      print_unit(minutes, minutes > 1 ? " minutes" : " minute", 1);
-      print_unit(seconds, seconds > 1 ? " seconds" : " second", 1);
-      terminal_writestring("\n");
-    }
-    else {
-      terminal_writestring("Current Uptime: ");
-      print_unit(hours, "h ", 0);
-      print_unit(minutes, "m ", 0);
-      print_unit(seconds, "s", 1);
-    }
+    uptime(args, argc);
   }
   else if (strcmp(cmd_name, "echo") == 0) {
-    int j = 1;
-    int skip_newline = 0;
-
-    while (j < argc && args[j][0] == '-') {
-      if (strcmp(args[j], "-n") == 0) {
-        skip_newline = 1;
-      }
-      else if (strcmp(args[j], "-h") == 0) {
-        terminal_writestring("echo - repeats your input to the console\n\n");
-        terminal_writestring("-h   - show this command\n");
-        terminal_writestring("-n   - do not output the trailing new line");
-        terminal_writestring("\n");
-        return;
-      }
-      else {
-        // No more recognized args
-        break;
-      }
-      j++;
-    }
-
-    while (j < argc) {
-      terminal_writestring(args[j]);
-      terminal_writestring(" ");
-      j++;
-    }
-
-    if (!skip_newline)
-      terminal_writestring("\n");
+    echo(args, argc);
   }
   else if (strcmp(cmd_name, "memdump") == 0) {
-    if (argc != 2) {
-      terminal_writestring("usage: memdump <size>\n");
-      return;
-    }
-    int size = atoi(args[1]);
-    if (size < 1 || size > 16384) {
-      terminal_writestring("memdump: size must be between 1-16384\n");
-      return;
-    }
-    pmm_dump_bitmap(size);
+    memdump(args, argc);
   }
   else if (strcmp(cmd_name, "mia") == 0) {
-    debug_trigger_page_fault();
+    mia();
   }
   else if (strcmp(cmd_name, "mmap") == 0) {
     mmu_view_mappings();
   }
   else if (strcmp(cmd_name, "peek") == 0) {
-    if (argc != 2) {
-      terminal_writestring("usage: peek <hex address>\n");
-      return;
-    }
-    uint32_t addr = htoi(args[1]);
-    mmu_debug_peek(addr);
-
+    peek(args, argc);
   }
   else if (strcmp(cmd_name, "poke") == 0) {
-    if (argc != 3) {
-      terminal_writestring("usage: poke <hex address> <hex value>\n");
-      return;
-    }
-    uint32_t addr = htoi(args[1]);
-    uint8_t value = (uint8_t) htoi(args[2]);
-    mmu_debug_poke(addr, value);
+    poke(args, argc);
   }
   else if (strcmp(cmd_name, "memtest") == 0) {
-    char *a = malloc(32);
-    char *b = malloc(100);
-    strlcpy(a, "heap ok", 8);
-    terminal_writestring("\nalloc a: ");
-    terminal_writestring(a);
-    free(a);
-    char *c = malloc(16);
-    terminal_writestring("\nreuse : ");
-    print_unit((uint32_t) (uintptr_t) c, "(addr)", 1);
-    free(b);
-    free(c);
+    memtest();
   } else {
     terminal_writestring("command not found: ");
     terminal_writestring(cmd_name);


### PR DESCRIPTION
This pull request refactors the shell command handling in the kernel by moving the implementation of built-in commands from `shell.c` into dedicated source files under `src/commands/`, and introducing a new header, `commands.h`, to declare these commands. The shell now calls these functions instead of containing their logic inline, resulting in a cleaner and more modular codebase. Additionally, new command implementations are added, and the Makefile is updated to include the new source directory.

The most important changes are:

### Command Refactoring and Modularity

* Extracted the logic for built-in shell commands (such as `help`, `fetch`, `crash`, `reboot`, `poweroff`, `mia`, `memtest`, `uptime`, `echo`, `memdump`, `peek`, and `poke`) from `src/kernel/shell.c` into individual source files under `src/commands/`, improving code organization and maintainability. The shell now calls these functions via the new `commands.h` interface. [[1]](diffhunk://#diff-efe6dbebca0db32c7dfc0ea1e9fd066bdd9f61d6f830df952bcbb0b7338ae932R1-R21) [[2]](diffhunk://#diff-86a30a836de2d5968a90cdc168b0c388e1f2d4d5bda8bf43326a005a49b563faL96-R123)
* Added `src/include/commands.h` to declare all shell command functions and a utility function, ensuring consistent usage throughout the codebase. [[1]](diffhunk://#diff-efe6dbebca0db32c7dfc0ea1e9fd066bdd9f61d6f830df952bcbb0b7338ae932R1-R21) [[2]](diffhunk://#diff-86a30a836de2d5968a90cdc168b0c388e1f2d4d5bda8bf43326a005a49b563faR13)

### New and Improved Command Implementations

* Improved or re-implemented command logic in their new files, including argument parsing, help messages, and output formatting for commands like `echo`, `uptime`, `memdump`, `peek`, and `poke`. [[1]](diffhunk://#diff-684f23fee2c8a3e5026e51eaeee018d55702ada5420bb9da6a9113067011ac6fR1-R36) [[2]](diffhunk://#diff-8af75322b4b78483d519fe5f6dc3d2f7f1361eba14d37cfacbb9b10063edbd94R1-R63) [[3]](diffhunk://#diff-25e879aa2b7fa95017dea01bf11217b6ba976eae69caaddf66fa8608dcf30a9dR1-R18) [[4]](diffhunk://#diff-e6e6fbe66428627349327f72c80808dceb9a1390afe11cc04fcf7697cb99e58bR1-R15) [[5]](diffhunk://#diff-e8dbac5712ba58533d8d23f1f7a6d4403d54556c270434c050893b7503f34781R1-R16)
* Added or updated commands such as `crash`, `fetch`, `help`, `memtest`, `mia`, `reboot`, and `poweroff` with clearer separation of concerns and better encapsulation. [[1]](diffhunk://#diff-99e0b64462d86e2b96a1969cb483336c4cee1092232b93fbd3c02745baac0958R1-R7) [[2]](diffhunk://#diff-6155ac727e83625530cefb790bde01cfca120f2618d417ca6d95f632aee5098fR1-R45) [[3]](diffhunk://#diff-2f735d5f9836e5c42794ad4f398506325dd32613c05003720995a3b67ca0df7bR1-R20) [[4]](diffhunk://#diff-8131975e4c9ff066b304a5ba1d11f9f7c69e25e873a0cac6b28be76766e60914R1-R19) [[5]](diffhunk://#diff-51fdee1294398daa800de3264f0eaeaf66f6dd5d04b1e322cd9f03670af4be66R1-R17) [[6]](diffhunk://#diff-05f01bfe866ab3f507d5a5f697a5b6577cd29fad00861cfc9f9cfaaa8f05dc9cR1-R11) [[7]](diffhunk://#diff-e2f12635045e61fb61c5658c9e098c6cee24b39ab003057ac4f558a7343c2df2R1-R10)

### Build System Update

* Updated the Makefile to include the new `src/commands/*.c` source files in the build process.

---

These changes make the shell easier to extend and maintain, and lay the groundwork for adding more commands in the future.