### PR TITLE
fix: reserve boot stack memory in init_mem function

### DIFF
--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -129,6 +129,8 @@ void init_mem(multiboot_info_t *mboot_ptr) {
     uint32_t bitmap_size = (max_ram_addr / 4096) / 8;
     pmm_mark_region_used(0x100000, (kernel_end_addr - 0x100000) + bitmap_size);
     pmm_mark_region_used(0x0, 4096);
+    // boot stack top is 0x90000 (loader.s), grows down: reserve 64 KB below it
+    pmm_mark_region_used(0x80000, 0x10000);
     KINFO("[PMM] Physical Memory Manager initialized by Zig.");
   }
   else {


### PR DESCRIPTION
This pull request makes a small but important change to the physical memory manager initialization in the kernel. It reserves the memory region used by the boot stack to prevent it from being overwritten.

Memory management:

* In `kernel.c`, added a call to `pmm_mark_region_used` to reserve the 64 KB region below `0x90000` (the boot stack area) to ensure the boot stack is not overwritten by the physical memory manager.